### PR TITLE
test: remove KeyPair import

### DIFF
--- a/tests/__tests__/linear/helper.ts
+++ b/tests/__tests__/linear/helper.ts
@@ -1,4 +1,4 @@
-import { Workspace, NEAR, NearAccount, BN, KeyPair } from "near-workspaces-ava";
+import { Workspace, NEAR, NearAccount, BN } from "near-workspaces-ava";
 
 interface RewardFee {
   numerator: number,
@@ -78,7 +78,6 @@ export async function callWithMetrics(
     options?: {
       gas?: string | BN;
       attachedDeposit?: string | BN;
-      signWithKey?: KeyPair;
     }
   ) {
     const txResult = await account.call_raw(contractId, methodName, args, options);


### PR DESCRIPTION
I suspect the testing failure `Can not sign transactions for account test.near on network sandbox, no matching key pair found in InMemorySigner(UnencryptedFileSystemKeyStore` is related to the import of `KeyPair` into `helper`.

Try to remove the import and try whether it works or not.