### PR TITLE
feat: add contract source metadata

### DIFF
--- a/contracts/linear/src/lib.rs
+++ b/contracts/linear/src/lib.rs
@@ -17,6 +17,7 @@ mod fungible_token;
 mod internal;
 mod legacy;
 mod liquidity_pool;
+mod metadata;
 mod owner;
 mod stake;
 mod types;

--- a/contracts/linear/src/metadata.rs
+++ b/contracts/linear/src/metadata.rs
@@ -1,0 +1,27 @@
+use crate::*;
+use near_sdk::near_bindgen;
+
+/// To make it easier for the contract to be audited and validated by community
+/// and 3rd party, we adopt [NEP-330 standard](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
+/// to make contract source metadata (including versions and source code links)
+/// available to auditors, developers and users.
+#[derive(Serialize)]
+#[serde(crate = "near_sdk::serde")]
+pub struct ContractSourceMetadata {
+    pub version: String,
+    pub link: String,
+}
+
+pub trait ContractSourceMetadataTrait {
+    fn contract_source_metadata(&self) -> ContractSourceMetadata;
+}
+
+#[near_bindgen]
+impl ContractSourceMetadataTrait for LiquidStakingContract {
+    fn contract_source_metadata(&self) -> ContractSourceMetadata {
+        ContractSourceMetadata {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            link: "https://github.com/linear-protocol/LiNEAR".to_string(),
+        }
+    }
+}

--- a/tests/__tests__/linear/metadata.ava.ts
+++ b/tests/__tests__/linear/metadata.ava.ts
@@ -1,4 +1,4 @@
-import { assertFailure, initWorkSpace } from "./helper";
+import { initWorkSpace } from "./helper";
 
 const workspace = initWorkSpace();
 

--- a/tests/__tests__/linear/metadata.ava.ts
+++ b/tests/__tests__/linear/metadata.ava.ts
@@ -1,0 +1,15 @@
+import { assertFailure, initWorkSpace } from "./helper";
+
+const workspace = initWorkSpace();
+
+interface ContractSourceMetadata {
+  version: String,
+  link: String,
+}
+
+workspace.test('read contract source metadata', async (test, { contract }) => {
+  test.is(
+    (await contract.view("contract_source_metadata", {}) as ContractSourceMetadata).link,
+    "https://github.com/linear-protocol/LiNEAR"
+  );
+});


### PR DESCRIPTION
Resolves: #93

For `version`, I didn't use a fixed commit hash because the commit might be created after the one to update the metadata. So I prefer using the git tag, which should be equal to the current `CARGO_PKG_VERSION`. 