### PR TITLE
feat: validator with base stake amount

### DIFF
--- a/bin/commands/set-node-base-amounts.js
+++ b/bin/commands/set-node-base-amounts.js
@@ -1,0 +1,112 @@
+const fs = require('fs');
+const { init } = require('../near');
+const prompts = require('prompts');
+const { Gas } = require('near-units');
+
+exports.command = 'set-node-base-amounts <address>';
+exports.desc = 'Set base stake amounts of nodes';
+exports.builder = yargs => {
+  yargs
+    .positional('address', {
+      describe: 'LiNEAR Contract address',
+      type: 'string'
+    })
+    .option('network', {
+      describe: 'network ID',
+      default: 'testnet',
+      choices: ['testnet', 'mainnet']
+    })
+    .demandOption(['signer', 'nodes'])
+    .option('signer', {
+      describe: 'signer account Id to call contract'
+    })
+    .option('nodes', {
+      describe: 'JSON file path which has nodes list'
+    })
+};
+
+exports.handler = async function (argv) {
+  const address = argv.address;
+  const filename = argv.nodes;
+  const file = fs.readFileSync(filename);
+  const nodes = JSON.parse(file.toString());
+
+  const near = await init(argv.network);
+  const signer = await near.account(argv.signer);
+  const contract = await near.account(address);
+
+  // currentNodes is a map from nodeID to validator struct
+  const currentNodes = await getValidators(contract);
+
+  const nodesToUpdateBaseStakeAmount = [];
+
+  for (const node of nodes) {
+    if (!currentNodes[node.id]) {
+      console.error(`Node [${node.id}] hasn't been added to list`);
+      continue;
+    }
+
+    // use yoctoNEAR instead of NEAR in config to take into account staking rewards
+    if (node.base_stake_amount != null && currentNodes[node.id].base != null 
+      && node.base_stake_amount.toString() !== currentNodes[node.id].base.toString()) {
+      nodesToUpdateBaseStakeAmount.push(node);        
+    }
+
+    delete currentNodes[node.id];
+  }
+
+  if (nodesToUpdateBaseStakeAmount.length > 0) {
+    console.log("Nodes to update base stake amount:");
+    console.log(nodesToUpdateBaseStakeAmount);
+  } else {
+    console.log("No nodes to update");
+    return ;
+  }
+
+  const res = await prompts({
+    type: 'confirm',
+    name: 'confirm',
+    message: 'Confirm update?'
+  });
+  if (!res.confirm) return;
+
+  const validators = nodesToUpdateBaseStakeAmount.map(node => node.id);
+  const amounts = nodesToUpdateBaseStakeAmount.map(node => node.base);
+  await signer.functionCall({
+    contractId: address,
+    methodName: 'update_base_stake_amounts',
+    args: {
+      validator_ids: validators,
+      amounts: amounts
+    },
+    gas: Gas.parse('300 Tgas')
+  });
+
+  console.log('done.');
+}
+
+async function getValidators(contract) {
+  let results = {};
+  let offset = 0;
+  const limit = 20;
+
+  while (true) {
+    const res = await contract.viewFunction(
+      contract.accountId,
+      'get_validators',
+      {
+        offset,
+        limit
+      }
+    );
+    if (res.length === 0) break;
+
+    offset += res.length;
+
+    for (const node of res) {
+      results[node.account_id] = node;
+    }
+  }
+
+  return results;
+}

--- a/contracts/linear/src/epoch_actions.rs
+++ b/contracts/linear/src/epoch_actions.rs
@@ -265,9 +265,11 @@ impl LiquidStakingContract {
 
         // make sure the validator:
         // 1. has weight set to 0
-        // 2. not in pending release
-        // 3. has not unstaked balance (because this part is from user's unstake request)
+        // 2. has base stake amount set to 0
+        // 3. not in pending release
+        // 4. has not unstaked balance (because this part is from user's unstake request)
         require!(validator.weight == 0, ERR_NON_ZERO_WEIGHT);
+        require!(validator.base_stake_amount == 0, ERR_NON_ZERO_BASE_STAKE_AMOUNT);
         require!(
             !validator.pending_release(),
             ERR_VALIDATOR_UNSTAKE_WHEN_LOCKED
@@ -313,9 +315,11 @@ impl LiquidStakingContract {
 
         // make sure the validator:
         // 1. has weight set to 0
-        // 2. has no staked balance
-        // 3. not pending release
+        // 2. has base stake amount set to 0
+        // 3. has no staked balance
+        // 4. not pending release
         require!(validator.weight == 0, ERR_NON_ZERO_WEIGHT);
+        require!(validator.base_stake_amount == 0, ERR_NON_ZERO_BASE_STAKE_AMOUNT);
         require!(validator.staked_amount == 0, ERR_NON_ZERO_STAKED_AMOUNT);
         require!(
             !validator.pending_release(),

--- a/contracts/linear/src/epoch_actions.rs
+++ b/contracts/linear/src/epoch_actions.rs
@@ -269,7 +269,10 @@ impl LiquidStakingContract {
         // 3. not in pending release
         // 4. has not unstaked balance (because this part is from user's unstake request)
         require!(validator.weight == 0, ERR_NON_ZERO_WEIGHT);
-        require!(validator.base_stake_amount == 0, ERR_NON_ZERO_BASE_STAKE_AMOUNT);
+        require!(
+            validator.base_stake_amount == 0,
+            ERR_NON_ZERO_BASE_STAKE_AMOUNT
+        );
         require!(
             !validator.pending_release(),
             ERR_VALIDATOR_UNSTAKE_WHEN_LOCKED
@@ -319,7 +322,10 @@ impl LiquidStakingContract {
         // 3. has no staked balance
         // 4. not pending release
         require!(validator.weight == 0, ERR_NON_ZERO_WEIGHT);
-        require!(validator.base_stake_amount == 0, ERR_NON_ZERO_BASE_STAKE_AMOUNT);
+        require!(
+            validator.base_stake_amount == 0,
+            ERR_NON_ZERO_BASE_STAKE_AMOUNT
+        );
         require!(validator.staked_amount == 0, ERR_NON_ZERO_STAKED_AMOUNT);
         require!(
             !validator.pending_release(),

--- a/contracts/linear/src/errors.rs
+++ b/contracts/linear/src/errors.rs
@@ -53,7 +53,8 @@ pub const ERR_SYNC_BALANCE_BAD_UNSTAKED: &str =
 
 // drain operations
 pub const ERR_NON_ZERO_WEIGHT: &str = "Validator weight must be zero for drain operation";
-pub const ERR_NON_ZERO_BASE_STAKE_AMOUNT: &str = "Validator base stake amount must be zero for drain operation";
+pub const ERR_NON_ZERO_BASE_STAKE_AMOUNT: &str =
+    "Validator base stake amount must be zero for drain operation";
 pub const ERR_NON_ZERO_UNSTAKED_AMOUNT: &str =
     "Validator unstaked amount must be zero when drain unstake";
 pub const ERR_NON_ZERO_STAKED_AMOUNT: &str =

--- a/contracts/linear/src/errors.rs
+++ b/contracts/linear/src/errors.rs
@@ -53,6 +53,7 @@ pub const ERR_SYNC_BALANCE_BAD_UNSTAKED: &str =
 
 // drain operations
 pub const ERR_NON_ZERO_WEIGHT: &str = "Validator weight must be zero for drain operation";
+pub const ERR_NON_ZERO_BASE_STAKE_AMOUNT: &str = "Validator base stake amount must be zero for drain operation";
 pub const ERR_NON_ZERO_UNSTAKED_AMOUNT: &str =
     "Validator unstaked amount must be zero when drain unstake";
 pub const ERR_NON_ZERO_STAKED_AMOUNT: &str =

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -117,10 +117,15 @@ pub enum Event<'a> {
         account_id: &'a AccountId,
         weight: u16,
     },
-    ValidatorUpdated {
+    ValidatorWeightUpdated {
         account_id: &'a AccountId,
-        base_stake_amount: &'a U128,
-        weight: u16,
+        old_weight: u16,
+        new_weight: u16,
+    },
+    ValidatorBaseStakeAmountUpdated {
+        account_id: &'a AccountId,
+        old_base_stake_amount: &'a U128,
+        new_base_stake_amount: &'a U128,
     },
     ValidatorRemoved {
         account_id: &'a AccountId,
@@ -593,19 +598,36 @@ mod tests {
     }
 
     #[test]
-    fn validator_updated() {
+    fn validator_weight_updated() {
         let account_id = &alice();
-        let base_stake_amount = &U128(50000);
-        let weight: u16 = 10;
-        Event::ValidatorUpdated {
+        let old_weight: u16 = 10;
+        let new_weight: u16 = 20;
+        Event::ValidatorWeightUpdated {
             account_id,
-            base_stake_amount,
-            weight,
+            old_weight,
+            new_weight,
         }
         .emit();
         assert_eq!(
             test_utils::get_logs()[0],
-            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated","data":[{"account_id":"alice","base_stake_amount":"50000","weight":10}]}"#
+            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_weight_updated","data":[{"account_id":"alice","old_weight":10,"new_weight":20}]}"#
+        );
+    }
+
+    #[test]
+    fn validator_base_stake_amount_updated() {
+        let account_id = &alice();
+        let old_base_stake_amount = &U128(0);
+        let new_base_stake_amount = &U128(50000);
+        Event::ValidatorBaseStakeAmountUpdated {
+            account_id,
+            old_base_stake_amount,
+            new_base_stake_amount,
+        }
+        .emit();
+        assert_eq!(
+            test_utils::get_logs()[0],
+            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_base_stake_amount_updated","data":[{"account_id":"alice","old_base_stake_amount":"0","new_base_stake_amount":"50000"}]}"#
         );
     }
 

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -1,4 +1,10 @@
-use near_sdk::{json_types::U128, log, serde::Serialize, serde_json::json, AccountId};
+use near_sdk::{
+    json_types::{I128, U128},
+    log,
+    serde::Serialize,
+    serde_json::json,
+    AccountId,
+};
 
 const EVENT_STANDARD: &str = "linear";
 const EVENT_STANDARD_VERSION: &str = "1.0.0";
@@ -123,6 +129,16 @@ pub enum Event<'a> {
     },
     ValidatorRemoved {
         account_id: &'a AccountId,
+    },
+    ValidatorStakeRequested {
+        account_id: &'a AccountId,
+        amount: &'a U128,
+        new_requested_stake_amount: &'a I128,
+    },
+    ValidatorUnstakeRequested {
+        account_id: &'a AccountId,
+        amount: &'a U128,
+        new_requested_stake_amount: &'a I128,
     },
     // Liquidity Pool
     #[deprecated(

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -119,15 +119,11 @@ pub enum Event<'a> {
     },
     ValidatorUpdated {
         account_id: &'a AccountId,
+        base_stake_amount: &'a U128,
         weight: u16,
     },
     ValidatorRemoved {
         account_id: &'a AccountId,
-    },
-    ValidatorBaseStakeAmountUpdated {
-        account_id: &'a AccountId,
-        old_base_stake_amount: &'a U128,
-        new_base_stake_amount: &'a U128,
     },
     // Liquidity Pool
     #[deprecated(
@@ -599,11 +595,12 @@ mod tests {
     #[test]
     fn validator_updated() {
         let account_id = &alice();
+        let base_stake_amount = &U128(50000);
         let weight: u16 = 10;
-        Event::ValidatorUpdated { account_id, weight }.emit();
+        Event::ValidatorUpdated { account_id, base_stake_amount, weight }.emit();
         assert_eq!(
             test_utils::get_logs()[0],
-            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated","data":[{"account_id":"alice","weight":10}]}"#
+            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated","data":[{"account_id":"alice","base_stake_amount":"50000","weight":10}]}"#
         );
     }
 

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -597,7 +597,12 @@ mod tests {
         let account_id = &alice();
         let base_stake_amount = &U128(50000);
         let weight: u16 = 10;
-        Event::ValidatorUpdated { account_id, base_stake_amount, weight }.emit();
+        Event::ValidatorUpdated {
+            account_id,
+            base_stake_amount,
+            weight,
+        }
+        .emit();
         assert_eq!(
             test_utils::get_logs()[0],
             r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated","data":[{"account_id":"alice","base_stake_amount":"50000","weight":10}]}"#

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -1,10 +1,4 @@
-use near_sdk::{
-    json_types::{I128, U128},
-    log,
-    serde::Serialize,
-    serde_json::json,
-    AccountId,
-};
+use near_sdk::{json_types::U128, log, serde::Serialize, serde_json::json, AccountId};
 
 const EVENT_STANDARD: &str = "linear";
 const EVENT_STANDARD_VERSION: &str = "1.0.0";
@@ -130,15 +124,10 @@ pub enum Event<'a> {
     ValidatorRemoved {
         account_id: &'a AccountId,
     },
-    ValidatorStakeRequested {
+    ValidatorBaseStakeAmountUpdated {
         account_id: &'a AccountId,
-        amount: &'a U128,
-        new_requested_stake_amount: &'a I128,
-    },
-    ValidatorUnstakeRequested {
-        account_id: &'a AccountId,
-        amount: &'a U128,
-        new_requested_stake_amount: &'a I128,
+        old_base_stake_amount: &'a U128,
+        new_base_stake_amount: &'a U128,
     },
     // Liquidity Pool
     #[deprecated(

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -117,12 +117,12 @@ pub enum Event<'a> {
         account_id: &'a AccountId,
         weight: u16,
     },
-    ValidatorWeightUpdated {
+    ValidatorUpdatedWeight {
         account_id: &'a AccountId,
         old_weight: u16,
         new_weight: u16,
     },
-    ValidatorBaseStakeAmountUpdated {
+    ValidatorUpdatedBaseStakeAmount {
         account_id: &'a AccountId,
         old_base_stake_amount: &'a U128,
         new_base_stake_amount: &'a U128,
@@ -598,11 +598,11 @@ mod tests {
     }
 
     #[test]
-    fn validator_weight_updated() {
+    fn validator_updated_weight() {
         let account_id = &alice();
         let old_weight: u16 = 10;
         let new_weight: u16 = 20;
-        Event::ValidatorWeightUpdated {
+        Event::ValidatorUpdatedWeight {
             account_id,
             old_weight,
             new_weight,
@@ -610,16 +610,16 @@ mod tests {
         .emit();
         assert_eq!(
             test_utils::get_logs()[0],
-            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_weight_updated","data":[{"account_id":"alice","old_weight":10,"new_weight":20}]}"#
+            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated_weight","data":[{"account_id":"alice","old_weight":10,"new_weight":20}]}"#
         );
     }
 
     #[test]
-    fn validator_base_stake_amount_updated() {
+    fn validator_updated_base_stake_amount() {
         let account_id = &alice();
         let old_base_stake_amount = &U128(0);
         let new_base_stake_amount = &U128(50000);
-        Event::ValidatorBaseStakeAmountUpdated {
+        Event::ValidatorUpdatedBaseStakeAmount {
             account_id,
             old_base_stake_amount,
             new_base_stake_amount,
@@ -627,7 +627,7 @@ mod tests {
         .emit();
         assert_eq!(
             test_utils::get_logs()[0],
-            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_base_stake_amount_updated","data":[{"account_id":"alice","old_base_stake_amount":"0","new_base_stake_amount":"50000"}]}"#
+            r#"EVENT_JSON:{"standard":"linear","version":"1.0.0","event":"validator_updated_base_stake_amount","data":[{"account_id":"alice","old_base_stake_amount":"0","new_base_stake_amount":"50000"}]}"#
         );
     }
 

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -391,7 +391,7 @@ impl LiquidStakingContract {
         self.validator_pool.update_weight(&validator_id, weight);
     }
 
-    pub fn update_base_stake_amount(&mut self, validator_ids: Vec<AccountId>, amounts: Vec<U128>) {
+    pub fn update_base_stake_amounts(&mut self, validator_ids: Vec<AccountId>, amounts: Vec<U128>) {
         self.assert_running();
         self.assert_manager();
         require!(validator_ids.len() == amounts.len(), ERR_BAD_VALIDATOR_LIST);

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -274,7 +274,7 @@ impl ValidatorPool {
                 / U256::from(self.total_base_stake_amount))
             .as_u128()
         };
-        // If not enough staked NEAR, satisfy the base stake amount first (set dynmaic stake amount to 0)
+        // If not enough staked NEAR, satisfy the base stake amount first (set dynamic stake amount to 0)
         let dynamic_stake_amount =
             if validator.weight == 0 || total_staked_near_amount <= self.total_base_stake_amount {
                 0

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -146,6 +146,7 @@ impl ValidatorPool {
 
         Event::ValidatorUpdated {
             account_id: validator_id,
+            base_stake_amount: &validator.base_stake_amount.into(),
             weight,
         }
         .emit();
@@ -163,10 +164,10 @@ impl ValidatorPool {
         self.toal_base_stake_amount = self.toal_base_stake_amount + amount - old_base_stake_amount;
         self.validators.insert(validator_id, &validator);
 
-        Event::ValidatorBaseStakeAmountUpdated {
+        Event::ValidatorUpdated {
             account_id: validator_id,
-            old_base_stake_amount: &old_base_stake_amount.into(),
-            new_base_stake_amount: &validator.base_stake_amount.into(),
+            base_stake_amount: &amount.into(),
+            weight: validator.weight,
         }
         .emit();
     }

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -138,16 +138,17 @@ impl ValidatorPool {
             .get(validator_id)
             .expect(ERR_VALIDATOR_NOT_EXIST);
 
+        let old_weight = validator.weight;
         // update total weight
-        self.total_weight = self.total_weight + weight - validator.weight;
+        self.total_weight = self.total_weight + weight - old_weight;
 
         validator.weight = weight;
         self.validators.insert(validator_id, &validator);
 
-        Event::ValidatorUpdated {
+        Event::ValidatorWeightUpdated {
             account_id: validator_id,
-            base_stake_amount: &validator.base_stake_amount.into(),
-            weight,
+            old_weight,
+            new_weight: weight,
         }
         .emit();
     }
@@ -160,15 +161,17 @@ impl ValidatorPool {
             .expect(ERR_VALIDATOR_NOT_EXIST);
 
         let old_base_stake_amount = validator.base_stake_amount;
-        validator.base_stake_amount = amount;
+        // update total base stake amount
         self.total_base_stake_amount =
             self.total_base_stake_amount + amount - old_base_stake_amount;
+
+        validator.base_stake_amount = amount;
         self.validators.insert(validator_id, &validator);
 
-        Event::ValidatorUpdated {
+        Event::ValidatorBaseStakeAmountUpdated {
             account_id: validator_id,
-            base_stake_amount: &amount.into(),
-            weight: validator.weight,
+            old_base_stake_amount: &old_base_stake_amount.into(),
+            new_base_stake_amount: &amount.into(),
         }
         .emit();
     }

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -693,7 +693,9 @@ mod tests {
 
         // set foo's base stake amount to 200
         validator_pool.update_base_stake_amount(&foo.account_id, 200 * ONE_NEAR);
-        foo = validator_pool.get_validator(&AccountId::new_unchecked("foo".to_string())).unwrap();
+        foo = validator_pool
+            .get_validator(&AccountId::new_unchecked("foo".to_string()))
+            .unwrap();
 
         // manually set staked amounts
         foo.staked_amount = 150 * ONE_NEAR; // target is 400
@@ -809,7 +811,9 @@ mod tests {
 
         // set foo's base stake amount to 200
         validator_pool.update_base_stake_amount(&foo.account_id, 200 * ONE_NEAR);
-        foo = validator_pool.get_validator(&AccountId::new_unchecked("foo".to_string())).unwrap();
+        foo = validator_pool
+            .get_validator(&AccountId::new_unchecked("foo".to_string()))
+            .unwrap();
 
         // manually set staked amounts
         foo.staked_amount = 100 * ONE_NEAR; // target is 250
@@ -855,7 +859,8 @@ mod tests {
 
         // in case no unstaking is needed
 
-        let (candidate, _) = validator_pool.get_candidate_to_unstake(100 * ONE_NEAR, 400 * ONE_NEAR);
+        let (candidate, _) =
+            validator_pool.get_candidate_to_unstake(100 * ONE_NEAR, 400 * ONE_NEAR);
         assert!(candidate.is_none());
     }
 }

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -247,6 +247,7 @@ impl ValidatorPool {
         (candidate, amount_to_unstake)
     }
 
+    /// target stake amount = base stake amount + dynamic stake amount proportional to weight
     fn validator_target_stake_amount(
         &self,
         total_staked_near_amount: Balance,
@@ -404,7 +405,7 @@ pub struct Validator {
     pub staked_amount: Balance,
     pub unstaked_amount: Balance,
 
-    /// The requested base stake amount on this validator.
+    /// The base stake amount on this validator.
     pub base_stake_amount: Balance,
 
     /// the epoch num when latest unstake action happened on this validator

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -145,7 +145,7 @@ impl ValidatorPool {
         validator.weight = weight;
         self.validators.insert(validator_id, &validator);
 
-        Event::ValidatorWeightUpdated {
+        Event::ValidatorUpdatedWeight {
             account_id: validator_id,
             old_weight,
             new_weight: weight,
@@ -168,7 +168,7 @@ impl ValidatorPool {
         validator.base_stake_amount = amount;
         self.validators.insert(validator_id, &validator);
 
-        Event::ValidatorBaseStakeAmountUpdated {
+        Event::ValidatorUpdatedBaseStakeAmount {
             account_id: validator_id,
             old_base_stake_amount: &old_base_stake_amount.into(),
             new_base_stake_amount: &amount.into(),

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -122,6 +122,7 @@ impl ValidatorPool {
         );
 
         self.total_weight -= validator.weight;
+        self.toal_base_stake_amount -= validator.base_stake_amount;
 
         Event::ValidatorRemoved {
             account_id: validator_id,

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -586,7 +586,7 @@ impl Validator {
 
     fn sync_base_stake_amount(&mut self, pool: &mut ValidatorPool, new_total_balance: Balance) {
         let old_total_balance = self.staked_amount + self.unstaked_amount;
-        // If no balance, or no base stake amount set, not need to update base stake amount
+        // If no balance, or no base stake amount set, no need to update base stake amount
         if old_total_balance != 0 && self.base_stake_amount != 0 {
             let old_base_stake_amount = self.base_stake_amount;
             self.base_stake_amount = (U256::from(old_base_stake_amount)

--- a/tests/__tests__/linear/drain.ava.ts
+++ b/tests/__tests__/linear/drain.ava.ts
@@ -1,5 +1,12 @@
 import { NearAccount, NEAR, Gas } from "near-workspaces-ava";
-import { assertFailure, initWorkSpace, createStakingPool, setManager, assertValidatorAmountHelper, updateBaseStakeAmounts } from "./helper";
+import {
+  assertFailure,
+  initWorkSpace,
+  createStakingPool,
+  setManager,
+  assertValidatorAmountHelper,
+  updateBaseStakeAmounts
+} from "./helper";
 
 const workspace = initWorkSpace();
 
@@ -274,7 +281,7 @@ workspace.test('drain unstake and withdraw', async (test, {contract, root, owner
    * Steps to drain a validator
    * 1. set weight to 0
    * 2. set base stake amount to 0
-   * 2. call drain_unstake
+   * 3. call drain_unstake
    * 4. call drain_withdraw
    */
 

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -362,7 +362,7 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await unstakeAll(owner, contract);
 
   // validators should have target stake amount based on weights + base stake amounts
-  // - 1st epoch_unstake() unstaked 12 NEAR from validator v1
+  // - 1st epoch_unstake() unstaked 12 NEAR from validator v1; however, the expectation is to only unstake 10 NEAR (base stake amount) from the validator
   await assertValidator(v1, '6', '14', '0');   // target = 6 (weighted); delta = 18 - 6 = 12;
   await assertValidator(v2, '22', '18', '0');  // target = 12 (weighted); delta = 22 - 12 = 10;
   await assertValidator(v3, '6', '54', '0');   // target = 18 (weighted); delta = 6 - 18 = -12;

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -325,8 +325,8 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await unstakeAll(owner, contract);
 
   // validators should have target stake amount based on weights + base stake amounts
-  // - 1st epoch_unstake() usntaked 24 NEAR from validator v3
-  // - 2nd epoch_unstake() usntaked 2 NEAR from validator v1
+  // - 1st epoch_unstake() unstaked 24 NEAR from validator v3
+  // - 2nd epoch_unstake() unstaked 2 NEAR from validator v1
   await assertValidator(v1, '18', '2', '10');   // target = 10 (base) + 6 (weighted) = 16; delta = 20 - 16 = 6; when 2nd epoch unstake: min3(6 * 2, 2, 20) = 2
   await assertValidator(v2, '22', '18', '0');  // target = 12 (weighted); delta = 22 - 12 = 10; when 2nd epoch unstake: min3(10 * 2, 2, 22) = 2
   await assertValidator(v3, '6', '54', '0');   // target = 18 (weighted); delta = 30 - 18 = 12; when 2nd epoch unstake: min3(12 * 2, 2, 6) = 2
@@ -362,7 +362,7 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await unstakeAll(owner, contract);
 
   // validators should have target stake amount based on weights + base stake amounts
-  // - 1st epoch_unstake() usntaked 12 NEAR from validator v1
+  // - 1st epoch_unstake() unstaked 12 NEAR from validator v1
   await assertValidator(v1, '6', '14', '0');   // target = 6 (weighted); delta = 18 - 6 = 12;
   await assertValidator(v2, '22', '18', '0');  // target = 12 (weighted); delta = 22 - 12 = 10;
   await assertValidator(v3, '6', '54', '0');   // target = 18 (weighted); delta = 6 - 18 = -12;

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -367,11 +367,11 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await unstakeAll(owner, contract);
 
   // validators should have target stake amount based on weights + base stake amounts
-  // - 1st epoch_unstake 24 NEAR on validator v3
-  // - 2nd epoch unstake 2 NEAR on validator v1
-  await assertValidator(v1, '18', '2');   // target = 10 (base) + 6 (weighted) = 16; delta = 20 - 16 = 6; when 2nd epoch_unstake: min3(6 * 2, 2, 20)
-  await assertValidator(v2, '22', '18');  // target = 12 (weighted); delta = 22 - 12 = 10; when 2nd epoch_unstake: min3(10 * 2, 2, 22)
-  await assertValidator(v3, '6', '54');   // target = 18 (weighted); delta = 30 - 18 = 12; when 2nd epoch_unstake: min3(12 * 2, 2, 6)
+  // - 1st epoch unstake 24 NEAR from validator v3
+  // - 2nd epoch unstake 2 NEAR from validator v1
+  await assertValidator(v1, '18', '2');   // target = 10 (base) + 6 (weighted) = 16; delta = 20 - 16 = 6; when 2nd epoch unstake: min3(6 * 2, 2, 20) = 2
+  await assertValidator(v2, '22', '18');  // target = 12 (weighted); delta = 22 - 12 = 10; when 2nd epoch unstake: min3(10 * 2, 2, 22) = 2
+  await assertValidator(v3, '6', '54');   // target = 18 (weighted); delta = 30 - 18 = 12; when 2nd epoch unstake: min3(12 * 2, 2, 6) = 2
 });
 
 workspace.test('epoch collect rewards', async (test, {root, contract, alice, owner}) => {

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -1,56 +1,7 @@
 import { Gas, NEAR, NearAccount, stake, } from "near-workspaces-ava";
-import { assertFailure, initWorkSpace, createStakingPool, updateBaseStakeAmounts, setManager } from "./helper";
+import { assertFailure, initWorkSpace, createStakingPool, updateBaseStakeAmounts, setManager, assertValidatorAmountHelper } from "./helper";
 
 const workspace = initWorkSpace();
-
-
-function assertValidatorAmountHelper (
-  test: any,
-  contract: NearAccount,
-  owner: NearAccount
-) {
-  return async function (
-    validator: NearAccount, 
-    stakedAmount: string,
-    unstakedAmount: string,
-    baseStakeAmount?: string,
-  ) {
-    // 1. make sure validator has correct balance
-    test.is(
-      await validator.view('get_account_staked_balance', { account_id: contract.accountId }),
-      NEAR.parse(stakedAmount).toString()
-    );
-    test.is(
-      await validator.view('get_account_unstaked_balance', { account_id: contract.accountId }),
-      NEAR.parse(unstakedAmount).toString()
-    );
-
-    // 2. make sure contract validator object is synced
-    const v: any = await contract.view(
-      'get_validator',
-      {
-        validator_id: validator.accountId
-      }
-    );
-    const staked = NEAR.from(v.staked_amount);
-    const unstaked = NEAR.from(v.unstaked_amount);
-    test.is(
-      staked.toString(),
-      NEAR.parse(stakedAmount).toString()
-    );
-    test.is(
-      unstaked.toString(),
-      NEAR.parse(unstakedAmount).toString()
-    );
-    if (baseStakeAmount) {
-      const baseStaked = NEAR.from(v.base_stake_amount);
-      test.is(
-        baseStaked.toString(),
-        NEAR.parse(baseStakeAmount).toString()
-      );
-    }
-  }
-}
 
 async function stakeAll (owner: NearAccount, contract: NearAccount) {
   let run = true;

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -367,8 +367,8 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await unstakeAll(owner, contract);
 
   // validators should have target stake amount based on weights + base stake amounts
-  // - 1st epoch unstake 24 NEAR from validator v3
-  // - 2nd epoch unstake 2 NEAR from validator v1
+  // - 1st epoch_unstake() usntaked 24 NEAR from validator v3
+  // - 2nd epoch_unstake() usntaked 2 NEAR from validator v1
   await assertValidator(v1, '18', '2');   // target = 10 (base) + 6 (weighted) = 16; delta = 20 - 16 = 6; when 2nd epoch unstake: min3(6 * 2, 2, 20) = 2
   await assertValidator(v2, '22', '18');  // target = 12 (weighted); delta = 22 - 12 = 10; when 2nd epoch unstake: min3(10 * 2, 2, 22) = 2
   await assertValidator(v3, '6', '54');   // target = 18 (weighted); delta = 30 - 18 = 12; when 2nd epoch unstake: min3(12 * 2, 2, 6) = 2
@@ -424,7 +424,7 @@ workspace.test('epoch collect rewards', async (test, {root, contract, alice, own
   // set manager
   const manager = await setManager(root, contract, owner);
 
-  // update base stake amount
+  // update base stake amount of v1 to 10 NEAR
   await updateBaseStakeAmounts(
     contract,
     manager,

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -1,5 +1,12 @@
 import { Gas, NEAR, NearAccount, stake, } from "near-workspaces-ava";
-import { assertFailure, initWorkSpace, createStakingPool, updateBaseStakeAmounts, setManager, assertValidatorAmountHelper } from "./helper";
+import {
+  assertFailure,
+  initWorkSpace,
+  createStakingPool,
+  updateBaseStakeAmounts,
+  setManager,
+  assertValidatorAmountHelper
+} from "./helper";
 
 const workspace = initWorkSpace();
 

--- a/tests/__tests__/linear/helper.ts
+++ b/tests/__tests__/linear/helper.ts
@@ -251,3 +251,51 @@ export async function updateBaseStakeAmounts(contract: NearAccount, manager: Nea
     }
   );
 }
+
+export function assertValidatorAmountHelper (
+  test: any,
+  contract: NearAccount,
+  owner: NearAccount
+) {
+  return async function (
+    validator: NearAccount,
+    stakedAmount: string,
+    unstakedAmount: string,
+    baseStakeAmount?: string,
+  ) {
+    // 1. make sure validator has correct balance
+    test.is(
+      await validator.view('get_account_staked_balance', { account_id: contract.accountId }),
+      NEAR.parse(stakedAmount).toString()
+    );
+    test.is(
+      await validator.view('get_account_unstaked_balance', { account_id: contract.accountId }),
+      NEAR.parse(unstakedAmount).toString()
+    );
+
+    // 2. make sure contract validator object is synced
+    const v: any = await contract.view(
+      'get_validator',
+      {
+        validator_id: validator.accountId
+      }
+    );
+    const staked = NEAR.from(v.staked_amount);
+    const unstaked = NEAR.from(v.unstaked_amount);
+    test.is(
+      staked.toString(),
+      NEAR.parse(stakedAmount).toString()
+    );
+    test.is(
+      unstaked.toString(),
+      NEAR.parse(unstakedAmount).toString()
+    );
+    if (baseStakeAmount) {
+      const baseStaked = NEAR.from(v.base_stake_amount);
+      test.is(
+        baseStaked.toString(),
+        NEAR.parse(baseStakeAmount).toString()
+      );
+    }
+  }
+}

--- a/tests/__tests__/linear/helper.ts
+++ b/tests/__tests__/linear/helper.ts
@@ -241,7 +241,12 @@ export async function setManager(root: NearAccount, contract: NearAccount, owner
   return manager;
 }
 
-export async function updateBaseStakeAmounts(contract: NearAccount, manager: NearAccount, validator_ids: string[], amounts: NEAR[]) {
+export async function updateBaseStakeAmounts(
+  contract: NearAccount,
+  manager: NearAccount,
+  validator_ids: string[],
+  amounts: NEAR[]
+) {
   await manager.call(
     contract,
     'update_base_stake_amounts',

--- a/tests/__tests__/linear/helper.ts
+++ b/tests/__tests__/linear/helper.ts
@@ -240,3 +240,14 @@ export async function setManager(root: NearAccount, contract: NearAccount, owner
 
   return manager;
 }
+
+export async function updateBaseStakeAmounts(contract: NearAccount, manager: NearAccount, validator_ids: string[], amounts: NEAR[]) {
+  await manager.call(
+    contract,
+    'update_base_stake_amounts',
+    {
+      validator_ids,
+      amounts
+    }
+  );
+}

--- a/tests/__tests__/linear/validator-pool.ava.ts
+++ b/tests/__tests__/linear/validator-pool.ava.ts
@@ -1,6 +1,6 @@
 import { Gas, NEAR } from "near-units";
 import { NearAccount } from "near-workspaces-ava";
-import { assertFailure, initAndSetWhitelist, initWorkSpace, } from "./helper";
+import { assertFailure, initAndSetWhitelist, initWorkSpace, updateBaseStakeAmounts, } from "./helper";
 
 const workspace = initWorkSpace();
 
@@ -79,13 +79,11 @@ workspace.test('not manager', async (test, { contract, alice, root, owner }) => 
 
   await assertFailure(
     test,
-    alice.call(
+    updateBaseStakeAmounts(
       contract,
-      'update_base_stake_amounts',
-      {
-        validator_ids: ['foo'],
-        amounts: [NEAR.parse("25,000")]
-      }
+      alice,
+      ['foo'],
+      [NEAR.parse("25,000")]
     ),
     errMsg
   );
@@ -466,19 +464,17 @@ workspace.test('update base stake amount', async (test, context) => {
 
   // update base stake amount of foo and bar
   const amounts = [
-    NEAR.parse("20000").toString(),
-    NEAR.parse("50000").toString()
+    NEAR.parse("20000"),
+    NEAR.parse("50000")
   ];
-  await manager.call(
+  await updateBaseStakeAmounts(
     contract,
-    'update_base_stake_amounts',
-    {
-      validator_ids: [
-        'foo',
-        'bar'
-      ],
-      amounts
-    }
+    manager,
+    [
+      'foo',
+      'bar'
+    ],
+    amounts
   );
 
   const foo: any = await contract.view(
@@ -489,7 +485,7 @@ workspace.test('update base stake amount', async (test, context) => {
   );
   test.is(
     foo.base_stake_amount,
-    amounts[0]
+    amounts[0].toString()
   );
 
   const bar: any = await contract.view(
@@ -500,6 +496,6 @@ workspace.test('update base stake amount', async (test, context) => {
   );
   test.is(
     bar.base_stake_amount,
-    amounts[1]
+    amounts[1].toString()
   );
 });

--- a/tests/__tests__/linear/validator-pool.ava.ts
+++ b/tests/__tests__/linear/validator-pool.ava.ts
@@ -81,7 +81,7 @@ workspace.test('not manager', async (test, { contract, alice, root, owner }) => 
     test,
     alice.call(
       contract,
-      'update_base_stake_amount',
+      'update_base_stake_amounts',
       {
         validator_ids: ['foo'],
         amounts: [NEAR.parse("25,000")]
@@ -471,7 +471,7 @@ workspace.test('update base stake amount', async (test, context) => {
   ];
   await manager.call(
     contract,
-    'update_base_stake_amount',
+    'update_base_stake_amounts',
     {
       validator_ids: [
         'foo',


### PR DESCRIPTION
### New Field Added to **`Validator`**

Upgrade the current validator pool design by adding a new field called `base_stake_amount` for each validator, which is needed for scheduling staking to Stake Wars III winners who will have a fixed base stake amount based on the DNP scores the validators get in [Stake Wars: Episode III](https://github.com/near/stakewars-iii). The field is `0` by default for other validators. 

```diff
pub struct Validator {
    pub account_id: AccountId,
    pub weight: u16,

    pub staked_amount: Balance,
    pub unstaked_amount: Balance,

+   /// The base stake amount on this validator.
+   pub base_stake_amount: Balance,

    /// the epoch num when latest unstake action happened on this validator
    pub unstake_fired_epoch: EpochHeight,
    /// this is to save the last value of unstake_fired_epoch,
    /// so that when unstake revert we can restore it
    pub last_unstake_fired_epoch: EpochHeight,
}
```

By adopting the updated model, we will have

> **formula: target stake amount = base stake amount + dynamic stake amount.**
>
> In this model, we ensure the sum of target stake amount is equal to the total staked amount,
> and prioritize base stake amount over dynamic stake amount.
>
> If total staked NEAR amount >= total base stake amount,
> 1. satisfy the base stake amount set by validator manager;
> 2. calculate dynamic stake amount proportional to weight
>
> If total staked NEAR amount < total base stake amount,
> 1. set dynamic stake amount to 0;
> 2. calculate the base stake amount proportionally


### New Function Added

This PR adds a new manager-only function 

```rs
fn update_base_stake_amount(&mut self, validator_ids: Vec<AccountId>, amounts: Vec<U128>);
```

which can update the base stake amounts for a list of validators. 


### How It Works

#### (1) Stake to Stake Wars III Winners

This will delegate the allocated NEAR amount to the Stake Wars winners. 

1. _NEAR Foundation_ adds the winners' validators into [whitelist](https://github.com/near/core-contracts/tree/master/whitelist), so lockup accounts and liquid staking protocols are allowed to stake to these validators. 
2. _LiNEAR validator manager_ adds the winners' validators into LiNEAR's validator pool. 
3. _LiNEAR validator manager_ updates the validators' base stake amount with the target delegation amount for each validator provided by NEAR Foundation. 
4. _NEAR Foundation_ will stake the total target NEAR amount to LiNEAR protocol.
5. When a new epoch starts, the target stake amount will be delegated to all the validators. 

#### (2) Unstake from Stake Wars III Winners

After the planned delegation period to the winners ends (e.g. after 12 months), NEAR Foundation can unstake the staked NEAR.

1. _LiNEAR validator manager_ updates the winner validators' base stake amount to `0`. 
2. _NEAR Foundation_ starts unstaking the LiNEAR it owns.
3. When a new epoch starts, the unstake will start on each validator because the target stake amount has been updated. 
4. After 4 epochs, _NEAR Founation_ will be able to withdraw the unstaked NEAR.

#### (3) Update Rewards

The base stake amount should be updated every epoch by taking into account the accumulated staking rewards.

1. When updating total balance of each validator, the base stake amount will also be updated proportionally.

#### (4) Remove Invalid Validators

If a validator is invalid or decided to be removed by NEAR Foundation, the LiNEAR validator manager account could reset the base stake amount, and even remove it from the validator pool.

1. _NEAR Foundation_ decides to remove some invalid validators, or _LiNEAR validator manager_ finds that some validators are obviously not functioning properly. 
1. _LiNEAR validator manager_ sets the validator's base stake amount to `0`. 
2. _LiNEAR validator manager_ drains the validator and removes it if not valid any more. 


### Notes

State migration is required when upgrading contract with this feature
