### PR TITLE
feat: `stake`, `stake_all` and `deposit_and_stake` return received LiNEAR amount

### DIFF
--- a/contracts/linear/src/internal.rs
+++ b/contracts/linear/src/internal.rs
@@ -74,7 +74,7 @@ impl LiquidStakingContract {
         Promise::new(account_id).transfer(amount);
     }
 
-    pub(crate) fn internal_stake(&mut self, amount: Balance) {
+    pub(crate) fn internal_stake(&mut self, amount: Balance) -> ShareBalance {
         self.assert_running();
 
         require!(amount > 0, ERR_NON_POSITIVE_STAKING_AMOUNT);
@@ -133,6 +133,8 @@ impl LiquidStakingContract {
             self.total_staked_near_amount,
             self.total_share_amount
         );
+
+        num_shares
     }
 
     pub(crate) fn internal_unstake(&mut self, amount: u128) {

--- a/contracts/linear/src/stake.rs
+++ b/contracts/linear/src/stake.rs
@@ -17,10 +17,10 @@ impl LiquidStakingContract {
 
     /// Deposits the attached amount into the inner account of the predecessor and stakes it.
     #[payable]
-    pub fn deposit_and_stake(&mut self) {
+    pub fn deposit_and_stake(&mut self) -> U128 {
         let amount = env::attached_deposit();
         self.internal_deposit(amount);
-        self.internal_stake(amount);
+        self.internal_stake(amount).into()
     }
 
     /// Withdraws the entire unstaked balance from the predecessor account.
@@ -47,9 +47,9 @@ impl LiquidStakingContract {
 
     /// Stakes the given amount from the inner account of the predecessor.
     /// The inner account should have enough unstaked balance.
-    pub fn stake(&mut self, amount: U128) {
+    pub fn stake(&mut self, amount: U128) -> U128 {
         let amount: Balance = amount.into();
-        self.internal_stake(amount);
+        self.internal_stake(amount).into()
     }
 
     /// Unstakes all staked balance from the inner account of the predecessor.

--- a/contracts/linear/src/stake.rs
+++ b/contracts/linear/src/stake.rs
@@ -16,6 +16,7 @@ impl LiquidStakingContract {
     }
 
     /// Deposits the attached amount into the inner account of the predecessor and stakes it.
+    /// - (since v1.3.0) Returns the received LiNEAR amount
     #[payable]
     pub fn deposit_and_stake(&mut self) -> U128 {
         let amount = env::attached_deposit();
@@ -39,14 +40,16 @@ impl LiquidStakingContract {
     }
 
     /// Stakes all available unstaked balance from the inner account of the predecessor.
-    pub fn stake_all(&mut self) {
+    /// - (since v1.3.0) Returns the received LiNEAR amount
+    pub fn stake_all(&mut self) -> U128 {
         let account_id = env::predecessor_account_id();
         let account = self.internal_get_account(&account_id);
-        self.internal_stake(account.unstaked);
+        self.internal_stake(account.unstaked).into()
     }
 
     /// Stakes the given amount from the inner account of the predecessor.
     /// The inner account should have enough unstaked balance.
+    /// - (since v1.3.0) Returns the received LiNEAR amount
     pub fn stake(&mut self, amount: U128) -> U128 {
         let amount: Balance = amount.into();
         self.internal_stake(amount).into()

--- a/tests/__tests__/linear/staking-pool-interface.ava.ts
+++ b/tests/__tests__/linear/staking-pool-interface.ava.ts
@@ -37,10 +37,14 @@ workspace.test('deposit first and stake later', async (test, {contract, alice}) 
 
   // stake
   const stakeAmount = NEAR.parse('9');
-  await alice.call(
+  let receivedLinearAmount = await alice.call(
     contract,
     'stake',
     { amount: stakeAmount.toString() }
+  );
+  test.is(
+    stakeAmount.toString(),
+    receivedLinearAmount.toString(),
   );
 
   test.is(
@@ -53,10 +57,14 @@ workspace.test('deposit first and stake later', async (test, {contract, alice}) 
   );
 
   // stake all
-  await alice.call(
+  receivedLinearAmount = await alice.call(
     contract,
     'stake_all',
     {}
+  );
+  test.is(
+    deposit.sub(stakeAmount).toString(),
+    receivedLinearAmount.toString(),
   );
 
   test.is(
@@ -72,11 +80,15 @@ workspace.test('deposit first and stake later', async (test, {contract, alice}) 
 workspace.test('deposit and stake', async (test, {contract, alice}) => {
   // deposit and stake
   const stakeAmount = NEAR.parse('10');
-  await alice.call(
+  const receivedLinearAmount = await alice.call(
     contract,
     'deposit_and_stake',
     {},
     { attachedDeposit: stakeAmount },
+  );
+  test.is(
+    stakeAmount.toString(),
+    receivedLinearAmount.toString(),
   );
 
   test.is(


### PR DESCRIPTION
This change is a backward compatible extension to the original staking pool interfaces, by adding return value, and has no change to function name and parameters, which is acceptable I think. 

