### PR TITLE
feat: validator pool state migration

### DIFF
--- a/contracts/linear/Cargo.toml
+++ b/contracts/linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear"
-version = "1.3.0"
+version = "1.2.0"
 authors = ["linguists", "dongcool"]
 edition = "2018"
 publish = false

--- a/contracts/linear/Cargo.toml
+++ b/contracts/linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["linguists", "dongcool"]
 edition = "2018"
 publish = false

--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -276,7 +276,7 @@ impl ValidatorPoolV1_0_0 {
                     weight: v.weight,
                     staked_amount: v.staked_amount,
                     unstaked_amount: v.unstaked_amount,
-                    base_stake_amount: 0,
+                    base_stake_amount: 0, // 0 by default
                     unstake_fired_epoch: v.unstake_fired_epoch,
                     last_unstake_fired_epoch: v.last_unstake_fired_epoch,
                 },

--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -14,10 +14,78 @@ use near_sdk::{
     near_bindgen, AccountId, Balance, EpochHeight, StorageUsage,
 };
 
-/// There's no root state change in v1.3.0
-/// ContractV1_3_0
-///
-/// The Validator struct has added `base_stake_amount` in v1.3.0
+/// There's no root state change in v1.3.0 since v1.1.0
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct ContractV1_3_0 {
+    /// The account ID of the owner
+    owner_id: AccountId,
+    /// The accounts that are able to change key parameters and settings in the contract such as validator pool membership
+    managers: UnorderedSet<AccountId>,
+    /// The account ID of the treasury that manages portion of the received fees and rewards.
+    treasury_id: AccountId,
+    /// Total amount of LiNEAR that was minted (minus burned).
+    total_share_amount: ShareBalance,
+    /// Total amount of NEAR that was staked by users to this contract.
+    ///
+    /// This is effectively 1) amount of NEAR that was deposited to this contract but hasn't yet been staked on any validators
+    /// plus 2) amount of NEAR that has already been staked on validators.
+    /// Note that the amount of NEAR that is pending release or is already released by hasn't been withdrawn is not considered.
+    total_staked_near_amount: Balance,
+    /// Persistent map from an account ID to the corresponding account.
+    accounts: UnorderedMap<AccountId, Account>,
+    /// Pause the contract for maintenance, all user interactions are stopped. Only the owner can perform pause and resume.
+    /// It doesn't affect the staking shares or reward distribution.
+    /// The contract is not paused by default.
+    paused: bool,
+
+    /// The storage size in bytes for one account.
+    account_storage_usage: StorageUsage,
+
+    /// Beneficiaries for staking rewards.
+    beneficiaries: UnorderedMap<AccountId, u32>,
+
+    /// The single-direction liquidity pool that enables instant unstake
+    liquidity_pool: LiquidityPool,
+
+    // --- Validator Pool ---
+    /// The validator pool that manage the actions against validators
+    validator_pool: ValidatorPool,
+    /// The whitelist contract ID, which controls the staking pool whitelist.
+    whitelist_account_id: Option<AccountId>,
+    /// Amount of NEAR that is requested to stake by all users during the last epoch
+    epoch_requested_stake_amount: Balance,
+    /// Amount of NEAR that is requested to unstake by all users during the last epoch
+    epoch_requested_unstake_amount: Balance,
+
+    /// Amount of NEAR that needs to be settled by staking on validators
+    stake_amount_to_settle: Balance,
+    /// Amount of NEAR that needs to be settled by unstaking from validators
+    unstake_amount_to_settle: Balance,
+    /// Last epoch height stake/unstake settlements were calculated
+    last_settlement_epoch: EpochHeight,
+
+    // --- Staking Farm ---
+    /// Farm tokens.
+    farms: Vector<Farm>,
+    /// Active farms: indicies into `farms`.
+    active_farms: Vec<u64>,
+    /// Authorized users, allowed to add farms.
+    /// This is done to prevent farm spam with random tokens.
+    /// Should not be a large number.
+    // authorized_users: UnorderedSet<AccountId>,
+    /// Authorized tokens for farms.
+    /// Required because any contract can call method with ft_transfer_call, so must verify that contract will accept it.
+    authorized_farm_tokens: UnorderedSet<AccountId>,
+}
+/// The ValidatorPool struct added `total_base_stake_amount` in v1.3.0
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct ValidatorPoolV1_3_0 {
+    pub validators: UnorderedMap<AccountId, Validator>,
+    pub total_weight: u16,
+    pub total_base_stake_amount: Balance,
+}
+/// The Validator struct added `base_stake_amount` in v1.3.0
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct ValidatorV1_3_0 {
     pub account_id: AccountId,

--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -280,7 +280,7 @@ impl ValidatorPoolV1_0_0 {
     pub fn migrate(&mut self) -> ValidatorPool {
         // migrate old validators into the new structure
         let mut new_validators: UnorderedMap<AccountId, VValidator> =
-            UnorderedMap::new(StorageKey::ValidatorsV2);
+            UnorderedMap::new(StorageKey::ValidatorsV1);
         let old_validators = self.validators.values_as_vector();
         for v in old_validators.iter() {
             new_validators.insert(&v.account_id.clone(), &v.into_validator().into());

--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -2,8 +2,7 @@
 //! when upgrading contract.
 use crate::account::Account;
 use crate::types::*;
-use crate::validator_pool::VValidator;
-use crate::validator_pool::Validator;
+use crate::validator_pool::{VValidator, Validator};
 use crate::Farm;
 use crate::Fraction;
 use crate::LiquidityPool;
@@ -238,15 +237,6 @@ pub struct ContractV1_0_0 {
     pub authorized_farm_tokens: UnorderedSet<AccountId>,
 }
 
-/// A pool of validators.
-/// The main function of this struct is to
-/// store validator info and calculate the best candidate to stake/unstake.
-#[derive(BorshSerialize, BorshDeserialize)]
-pub struct ValidatorPoolV1_0_0 {
-    validators: UnorderedMap<AccountId, ValidatorV1_0_0>,
-    total_weight: u16,
-}
-
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct ValidatorV1_0_0 {
     pub account_id: AccountId,
@@ -274,6 +264,15 @@ impl ValidatorV1_0_0 {
             last_unstake_fired_epoch: self.last_unstake_fired_epoch,
         }
     }
+}
+
+/// A pool of validators.
+/// The main function of this struct is to
+/// store validator info and calculate the best candidate to stake/unstake.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct ValidatorPoolV1_0_0 {
+    validators: UnorderedMap<AccountId, ValidatorV1_0_0>,
+    total_weight: u16,
 }
 
 /// --- ValidatorPool state migration --

--- a/contracts/linear/src/lib.rs
+++ b/contracts/linear/src/lib.rs
@@ -45,6 +45,7 @@ pub(crate) enum StorageKey {
     // AuthorizedUsers,
     AuthorizedFarmTokens,
     Managers,
+    ValidatorsV2,
 }
 
 #[near_bindgen]

--- a/contracts/linear/src/lib.rs
+++ b/contracts/linear/src/lib.rs
@@ -40,12 +40,12 @@ pub(crate) enum StorageKey {
     Accounts,
     Shares,
     Beneficiaries,
-    Validators,
+    Validators, // V0
     Farms,
     // AuthorizedUsers,
     AuthorizedFarmTokens,
     Managers,
-    ValidatorsV2,
+    ValidatorsV1,
 }
 
 #[near_bindgen]

--- a/contracts/linear/src/upgrade.rs
+++ b/contracts/linear/src/upgrade.rs
@@ -1,4 +1,4 @@
-// use crate::legacy::*;
+use crate::legacy::*;
 use crate::*;
 
 #[near_bindgen]
@@ -11,8 +11,30 @@ impl LiquidStakingContract {
     #[init(ignore_state)]
     #[private]
     pub fn migrate() -> Self {
-        let contract: LiquidStakingContract = env::state_read().expect("ERR_NOT_INITIALIZED");
-        contract
+        let mut contract: ContractV1_1_0 = env::state_read().expect("ERR_NOT_INITIALIZED");
+        let new_validator_pool = contract.validator_pool.migrate();
+        Self {
+            owner_id: contract.owner_id,
+            managers: contract.managers,
+            treasury_id: contract.treasury_id,
+            total_share_amount: contract.total_share_amount,
+            total_staked_near_amount: contract.total_staked_near_amount,
+            accounts: contract.accounts,
+            paused: contract.paused,
+            account_storage_usage: contract.account_storage_usage,
+            beneficiaries: contract.beneficiaries,
+            liquidity_pool: contract.liquidity_pool,
+            validator_pool: new_validator_pool,
+            whitelist_account_id: contract.whitelist_account_id,
+            epoch_requested_stake_amount: contract.epoch_requested_stake_amount,
+            epoch_requested_unstake_amount: contract.epoch_requested_unstake_amount,
+            stake_amount_to_settle: contract.stake_amount_to_settle,
+            unstake_amount_to_settle: contract.unstake_amount_to_settle,
+            last_settlement_epoch: contract.last_settlement_epoch,
+            farms: contract.farms,
+            active_farms: contract.active_farms,
+            authorized_farm_tokens: contract.authorized_farm_tokens,
+        }
     }
 }
 

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -56,9 +56,9 @@ trait WhitelistCallback {
 /// store validator info and calculate the best candidate to stake/unstake.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct ValidatorPool {
-    validators: UnorderedMap<AccountId, Validator>,
-    total_weight: u16,
-    total_base_stake_amount: Balance,
+    pub validators: UnorderedMap<AccountId, Validator>,
+    pub total_weight: u16,
+    pub total_base_stake_amount: Balance,
 }
 
 impl Default for ValidatorPool {

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -1,5 +1,6 @@
 use crate::errors::*;
 use crate::events::Event;
+use crate::legacy::ValidatorV1_0_0;
 use crate::types::*;
 use crate::utils::*;
 use crate::*;
@@ -56,7 +57,7 @@ trait WhitelistCallback {
 /// store validator info and calculate the best candidate to stake/unstake.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct ValidatorPool {
-    pub validators: UnorderedMap<AccountId, Validator>,
+    pub validators: UnorderedMap<AccountId, VValidator>,
     pub total_weight: u16,
     pub total_base_stake_amount: Balance,
 }
@@ -81,11 +82,14 @@ impl ValidatorPool {
     }
 
     pub fn get_validator(&self, validator_id: &AccountId) -> Option<Validator> {
-        self.validators.get(validator_id)
+        self.validators
+            .get(validator_id)
+            .map(|v| v.into_validator())
     }
 
     pub fn save_validator(&mut self, validator: &Validator) {
-        self.validators.insert(&validator.account_id, validator);
+        self.validators
+            .insert(&validator.account_id, &(validator.clone().into()));
     }
 
     pub fn add_validator(&mut self, validator_id: &AccountId, weight: u16) -> Validator {
@@ -96,7 +100,8 @@ impl ValidatorPool {
 
         let validator = Validator::new(validator_id.clone(), weight);
 
-        self.validators.insert(validator_id, &validator);
+        self.validators
+            .insert(validator_id, &validator.clone().into());
 
         self.total_weight += weight;
 
@@ -113,7 +118,8 @@ impl ValidatorPool {
         let validator = self
             .validators
             .remove(validator_id)
-            .expect(ERR_VALIDATOR_NOT_EXIST);
+            .expect(ERR_VALIDATOR_NOT_EXIST)
+            .into_validator();
 
         // make sure this validator is not used at all
         require!(
@@ -136,14 +142,15 @@ impl ValidatorPool {
         let mut validator = self
             .validators
             .get(validator_id)
-            .expect(ERR_VALIDATOR_NOT_EXIST);
+            .expect(ERR_VALIDATOR_NOT_EXIST)
+            .into_validator();
 
         let old_weight = validator.weight;
         // update total weight
         self.total_weight = self.total_weight + weight - old_weight;
 
         validator.weight = weight;
-        self.validators.insert(validator_id, &validator);
+        self.validators.insert(validator_id, &validator.into());
 
         Event::ValidatorUpdatedWeight {
             account_id: validator_id,
@@ -158,7 +165,8 @@ impl ValidatorPool {
         let mut validator = self
             .validators
             .get(validator_id)
-            .expect(ERR_VALIDATOR_NOT_EXIST);
+            .expect(ERR_VALIDATOR_NOT_EXIST)
+            .into_validator();
 
         let old_base_stake_amount = validator.base_stake_amount;
         // update total base stake amount
@@ -166,7 +174,7 @@ impl ValidatorPool {
             self.total_base_stake_amount + amount - old_base_stake_amount;
 
         validator.base_stake_amount = amount;
-        self.validators.insert(validator_id, &validator);
+        self.validators.insert(validator_id, &validator.into());
 
         Event::ValidatorUpdatedBaseStakeAmount {
             account_id: validator_id,
@@ -192,6 +200,7 @@ impl ValidatorPool {
         let mut amount_to_stake: Balance = 0;
 
         for (_, validator) in self.validators.iter() {
+            let validator = validator.into_validator();
             let target_amount =
                 self.validator_target_stake_amount(total_staked_near_amount, &validator);
             if validator.staked_amount < target_amount {
@@ -220,6 +229,7 @@ impl ValidatorPool {
         let mut amount_to_unstake: Balance = 0;
 
         for (_, validator) in self.validators.iter() {
+            let validator = validator.into_validator();
             if validator.pending_release() {
                 continue;
             }
@@ -291,6 +301,7 @@ impl ValidatorPool {
         let mut available_amount: Balance = 0;
         let mut total_staked_amount: Balance = 0;
         for validator in self.validators.values() {
+            let validator = validator.into_validator();
             total_staked_amount += validator.staked_amount;
 
             if !validator.pending_release() && validator.staked_amount > 0 {
@@ -600,6 +611,27 @@ impl LiquidStakingContract {
     }
 }
 
+#[derive(BorshSerialize, BorshDeserialize)]
+pub enum VValidator {
+    V0(ValidatorV1_0_0),
+    Current(Validator),
+}
+
+impl VValidator {
+    pub fn into_validator(self) -> Validator {
+        match self {
+            VValidator::V0(v) => v.into_validator(),
+            VValidator::Current(v) => v,
+        }
+    }
+}
+
+impl From<Validator> for VValidator {
+    fn from(v: Validator) -> Self {
+        VValidator::Current(v)
+    }
+}
+
 /// struct for staking pool validator
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
@@ -845,9 +877,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 150
         bar.staked_amount = 200 * ONE_NEAR; // target is 150
         zoo.staked_amount = 200 * ONE_NEAR; // target is 300
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 600 in total, 500 already staked, 100 to stake,
         // each weight point should be 150, thus zoo is the most unbalanced one.
@@ -862,9 +900,15 @@ mod tests {
         foo.staked_amount = 0; // target is 150
         bar.staked_amount = 200 * ONE_NEAR; // target is 150
         zoo.staked_amount = 300 * ONE_NEAR; // target is 150
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 600 in total, 500 already staked, 100 to stake,
         // each weight point should be 150, thus zoo is the most unbalanced one.
@@ -879,9 +923,15 @@ mod tests {
         foo.staked_amount = 200 * ONE_NEAR; // target is 150
         bar.staked_amount = 200 * ONE_NEAR; // target is 150
         zoo.staked_amount = 300 * ONE_NEAR; // target is 300
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // in case no staking is needed
 
@@ -909,9 +959,15 @@ mod tests {
         foo.staked_amount = 150 * ONE_NEAR; // target is 400
         bar.staked_amount = 200 * ONE_NEAR; // target is 200
         zoo.staked_amount = 200 * ONE_NEAR; // target is 400
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 1000 in total, 550 already staked, 250 to stake,
         // each weight point should be 200, thus foo is the most unbalanced one.
@@ -926,9 +982,15 @@ mod tests {
         foo.staked_amount = 0; // target is 350
         bar.staked_amount = 200 * ONE_NEAR; // target is 150
         zoo.staked_amount = 300 * ONE_NEAR; // target is 300
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 800 in total, 500 already staked, 200 to stake,
         // each weight point should be 150, thus foo is the most unbalanced one.
@@ -943,9 +1005,15 @@ mod tests {
         foo.staked_amount = 500 * ONE_NEAR; // target is 400
         bar.staked_amount = 300 * ONE_NEAR; // target is 200
         zoo.staked_amount = 500 * ONE_NEAR; // target is 400
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // in case no staking is needed
 
@@ -958,9 +1026,15 @@ mod tests {
         foo.staked_amount = 0; // target is 100
         bar.staked_amount = 20 * ONE_NEAR; // target is 0
         zoo.staked_amount = 30 * ONE_NEAR; // target is 0
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 100 in total, 50 already staked, 50 to stake,
         // the total stake amount is less than total base stake amount, satisfay base stake amount first.
@@ -982,9 +1056,15 @@ mod tests {
         foo.staked_amount = 75 * ONE_NEAR; // target is 100
         bar.staked_amount = 20 * ONE_NEAR; // target is 50
         zoo.staked_amount = 5 * ONE_NEAR; // target is 0
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 150 in total, 100 already staked, 50 to stake,
         // the total stake amount is less than total base stake amount, satisfay base stake amount first.
@@ -1009,9 +1089,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 100
         bar.staked_amount = 100 * ONE_NEAR; // target is 100
         zoo.staked_amount = 210 * ONE_NEAR; // target is 200
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 510 already staked, 110 to unstake, target total 400,
         // each weight point should be 100, thus zoo is the most unbalanced one.
@@ -1026,9 +1112,15 @@ mod tests {
         foo.staked_amount = 100; // target is 100
         bar.staked_amount = 200 * ONE_NEAR; // target is 100
         zoo.staked_amount = 200 * ONE_NEAR; // target is 200
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 500 already staked, 100 to unstake, target total 400,
         // each weight point should be 100, thus bar is the most unbalanced one.
@@ -1043,9 +1135,15 @@ mod tests {
         foo.staked_amount = 100;
         bar.staked_amount = 100;
         zoo.staked_amount = 100;
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // in case no unstaking is needed
 
@@ -1073,9 +1171,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 250
         bar.staked_amount = 100 * ONE_NEAR; // target is 50
         zoo.staked_amount = 210 * ONE_NEAR; // target is 100
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 510 already staked, 110 to unstake, target total 400,
         // each weight point should be 50, thus zoo is the most unbalanced one.
@@ -1090,9 +1194,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 250
         bar.staked_amount = 200 * ONE_NEAR; // target is 50
         zoo.staked_amount = 200 * ONE_NEAR; // target is 100
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 500 already staked, 100 to unstake, target total 400,
         // each weight point should be 50, thus bar is the most unbalanced one.
@@ -1107,9 +1217,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR;
         bar.staked_amount = 50 * ONE_NEAR;
         zoo.staked_amount = 100 * ONE_NEAR;
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // in case no unstaking is needed
 
@@ -1123,9 +1239,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 200
         bar.staked_amount = 150 * ONE_NEAR; // target is 0
         zoo.staked_amount = 200 * ONE_NEAR; // target is 0
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 450 already staked, 250 to unstake, target total 200,
         // the total stake amount is less than total base stake amount, satisfay base stake amount first,
@@ -1147,9 +1269,15 @@ mod tests {
         foo.staked_amount = 100 * ONE_NEAR; // target is 100
         bar.staked_amount = 150 * ONE_NEAR; // target is 50
         zoo.staked_amount = 50 * ONE_NEAR; // target is 0
-        validator_pool.validators.insert(&foo.account_id, &foo);
-        validator_pool.validators.insert(&bar.account_id, &bar);
-        validator_pool.validators.insert(&zoo.account_id, &zoo);
+        validator_pool
+            .validators
+            .insert(&foo.account_id, &foo.clone().into());
+        validator_pool
+            .validators
+            .insert(&bar.account_id, &bar.clone().into());
+        validator_pool
+            .validators
+            .insert(&zoo.account_id, &zoo.clone().into());
 
         // we have currently 300 already staked, 150 to unstake, target total 150,
         // the total stake amount is less than total base stake amount, satisfay base stake amount first,

--- a/tests/__tests__/linear/upgrade.ava.ts
+++ b/tests/__tests__/linear/upgrade.ava.ts
@@ -26,7 +26,7 @@ async function upgrade(contract: NearAccount, owner: NearAccount) {
     "upgrade",
     readFileSync("compiled-contracts/linear.wasm"),
     {
-      gas: Gas.parse("200 Tgas"),
+      gas: Gas.parse("300 Tgas"),
     }
   );
 }

--- a/tests/__tests__/linear/upgrade.ava.ts
+++ b/tests/__tests__/linear/upgrade.ava.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from "fs";
+import { Gas, NEAR } from "near-units";
+import { NearAccount, Workspace } from "near-workspaces-ava";
+import { createStakingPool, initAndSetWhitelist, skip, updateBaseStakeAmounts, } from "./helper";
+
+async function deployLinearV1_2_0(
+  root: NearAccount,
+  owner_id: string,
+  contractId = 'linear',
+) {
+  return root.createAndDeploy(
+    contractId,
+    'compiled-contracts/linear_v1_2_0.wasm',
+    {
+      method: 'new',
+      args: {
+        owner_id,
+      }
+    }
+  )
+}
+
+async function upgrade(contract: NearAccount, owner: NearAccount) {
+  await owner.call(
+    contract,
+    "upgrade",
+    readFileSync("compiled-contracts/linear.wasm"),
+    {
+      gas: Gas.parse("200 Tgas"),
+    }
+  );
+}
+
+async function stakeAll (signer: NearAccount, contract: NearAccount) {
+  let run = true;
+  while (run) {
+    run = await signer.call(
+      contract,
+      'epoch_stake',
+      {},
+      {
+        gas: Gas.parse('300 Tgas')
+      }
+    );
+  }
+}
+
+function initWorkSpace() {
+  return Workspace.init(async ({ root }) => {
+    // deposit 1M $NEAR for each account
+    const owner = await root.createAccount('linear_owner', { initialBalance: NEAR.parse("1000000").toString() });
+    const alice = await root.createAccount('alice', { initialBalance: NEAR.parse("1000000").toString() });
+    const bob = await root.createAccount('bob', { initialBalance: NEAR.parse("1000000").toString() });
+    const carol = await root.createAccount('carol', { initialBalance: NEAR.parse("1000000").toString() });
+
+    const contract = await deployLinearV1_2_0(root, owner.accountId);
+
+    await initAndSetWhitelist(root, contract, owner, true);
+
+    return { contract, owner, alice, bob, carol, };
+  });
+}
+
+const workspace = initWorkSpace();
+
+async function setManager(root: NearAccount, contract: NearAccount, owner: NearAccount) {
+  const manager = await root.createAccount('linear_manager', { initialBalance: NEAR.parse("1000000").toString() });
+
+  // set manager
+  await owner.call(
+    contract,
+    'add_manager',
+    {
+      new_manager_id: manager.accountId
+    }
+  );
+
+  return manager;
+}
+
+// The upgrade() test has run successfully in sandbox by migrating the states of 50 validators.
+// Skip the test in CI because upgrade varies between versions and is almost a one-time effort.
+// Keep this test case to make it easier to be reused in future upgrade.
+skip('upgrade contract from v1.2.0 to v1.3.0 on testnet', async (test, context) => {
+  const { root, contract, owner, alice, bob } = context;
+  const manager = await setManager(root, contract, owner);
+
+  const groups = 10;
+  const limit = 5;
+
+  // set up validators
+  for (let i = 0; i < groups; i++) {
+    const names = Array.from({ length: limit }, (_, j) => `validator-${i}-${j}`);
+    const weights = names.map(_ => 1);
+    const validators = await Promise.all(names.map(name => createStakingPool(root, name)));
+
+    await manager.call(
+      contract,
+      'add_validators',
+      {
+        validator_ids: validators.map(v => v.accountId),
+        weights
+      },
+      {
+        gas: Gas.parse('300 Tgas')
+      }
+    );
+  }
+
+  test.is(
+    await contract.view('get_total_weight'),
+    groups * limit
+  );
+
+  // user stake
+  const staked = 5000;
+  await alice.call(
+    contract,
+    'deposit_and_stake',
+    {},
+    {
+      attachedDeposit: NEAR.parse((staked-10).toFixed(0))
+    }
+  );
+
+  // run epoch stake
+  await stakeAll(bob, contract);
+
+
+  // read all validators
+  for (let i = 0; i < groups; i++) {
+    const offset = i * limit;
+
+    const validators: any = await contract.view(
+      'get_validators',
+      {
+        offset,
+        limit
+      }
+    );
+    for (const v of validators) {
+      test.is(
+        v.staked_amount,
+        NEAR.parse((staked / groups / limit).toFixed(0)).toString()
+      );
+      test.is(
+        v.base_stake_amount,
+        undefined
+      );
+    }
+  }
+
+  // upgrade linear contract to the latest
+  await upgrade(contract, owner);
+
+  // read all validators
+  for (let i = 0; i < groups; i++) {
+    const offset = i * limit;
+
+    const validators: any = await contract.view(
+      'get_validators',
+      {
+        offset,
+        limit
+      }
+    );
+    for (const v of validators) {
+      test.is(
+        v.staked_amount,
+        NEAR.parse((staked / groups / limit).toFixed(0)).toString()
+      );
+      test.is(
+        v.base_stake_amount,
+        '0'
+      );
+    }
+  }
+
+  test.is(
+    await contract.view('get_total_weight'),
+    groups * limit
+  );
+
+
+  // update base stake amount after upgrade
+
+  // add foo, bar
+  await manager.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: 'foo',
+      weight: 10
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+  await manager.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: 'bar',
+      weight: 20
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+
+  // update base stake amount of foo and bar
+  const amounts = [
+    NEAR.parse("20000"),
+    NEAR.parse("50000")
+  ];
+  await updateBaseStakeAmounts(
+    contract,
+    manager,
+    [
+      'foo',
+      'bar'
+    ],
+    amounts
+  );
+
+  const foo: any = await contract.view(
+    'get_validator',
+    {
+      validator_id: 'foo'
+    }
+  );
+  test.is(
+    foo.base_stake_amount,
+    amounts[0].toString()
+  );
+
+  const bar: any = await contract.view(
+    'get_validator',
+    {
+      validator_id: 'bar'
+    }
+  );
+  test.is(
+    bar.base_stake_amount,
+    amounts[1].toString()
+  );
+});


### PR DESCRIPTION
Changes in the PR:

- Migrate contract states to v1.3.0
- Simulating migration in sandbox with 50 validators

Issues Met

- Try migrating states of 100 validators and failed with `GasLimitExceeded` (exceeds 300 Tgas limit per transaction). 