### PR TITLE
refactor: rename `VValidator` to `VersionedValidator`

### DIFF
--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -2,7 +2,7 @@
 //! when upgrading contract.
 use crate::account::Account;
 use crate::types::*;
-use crate::validator_pool::{VValidator, Validator};
+use crate::validator_pool::{VersionedValidator, Validator};
 use crate::Farm;
 use crate::Fraction;
 use crate::LiquidityPool;
@@ -279,7 +279,7 @@ pub struct ValidatorPoolV1_0_0 {
 impl ValidatorPoolV1_0_0 {
     pub fn migrate(&mut self) -> ValidatorPool {
         // migrate old validators into the new structure
-        let mut new_validators: UnorderedMap<AccountId, VValidator> =
+        let mut new_validators: UnorderedMap<AccountId, VersionedValidator> =
             UnorderedMap::new(StorageKey::ValidatorsV1);
         let old_validators = self.validators.values_as_vector();
         for v in old_validators.iter() {

--- a/contracts/linear/src/legacy.rs
+++ b/contracts/linear/src/legacy.rs
@@ -2,7 +2,7 @@
 //! when upgrading contract.
 use crate::account::Account;
 use crate::types::*;
-use crate::validator_pool::{VersionedValidator, Validator};
+use crate::validator_pool::{Validator, VersionedValidator};
 use crate::Farm;
 use crate::Fraction;
 use crate::LiquidityPool;

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -57,7 +57,7 @@ trait WhitelistCallback {
 /// store validator info and calculate the best candidate to stake/unstake.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct ValidatorPool {
-    pub validators: UnorderedMap<AccountId, VValidator>,
+    pub validators: UnorderedMap<AccountId, VersionedValidator>,
     pub total_weight: u16,
     pub total_base_stake_amount: Balance,
 }
@@ -624,23 +624,23 @@ impl LiquidStakingContract {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
-pub enum VValidator {
+pub enum VersionedValidator {
     V0(ValidatorV1_0_0),
     Current(Validator),
 }
 
-impl VValidator {
+impl VersionedValidator {
     pub fn into_validator(self) -> Validator {
         match self {
-            VValidator::V0(v) => v.into_validator(),
-            VValidator::Current(v) => v,
+            VersionedValidator::V0(v) => v.into_validator(),
+            VersionedValidator::Current(v) => v,
         }
     }
 }
 
-impl From<Validator> for VValidator {
+impl From<Validator> for VersionedValidator {
     fn from(v: Validator) -> Self {
-        VValidator::Current(v)
+        VersionedValidator::Current(v)
     }
 }
 


### PR DESCRIPTION
Related: https://github.com/linear-protocol/LiNEAR/pull/136#discussion_r1090226734