### PR TITLE
chore: release v1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "linear"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "near-contract-standards",
  "near-sdk 4.0.0-pre.7",

--- a/contracts/linear/Cargo.toml
+++ b/contracts/linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["linguists", "dongcool"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
Release a new version for fixing potential `epoch_unstake()` failure in staging env.