### PR TITLE
feat: allow epoch update rewards for validators with no staked and unstaked amount

### DIFF
--- a/contracts/linear/src/epoch_actions.rs
+++ b/contracts/linear/src/epoch_actions.rs
@@ -175,10 +175,6 @@ impl LiquidStakingContract {
             .get_validator(&validator_id)
             .expect(ERR_VALIDATOR_NOT_EXIST);
 
-        if validator.staked_amount == 0 && validator.unstaked_amount == 0 {
-            return;
-        }
-
         validator
             .refresh_total_balance(&mut self.validator_pool)
             .then(ext_self_action_cb::validator_get_balance_callback(

--- a/contracts/mock-staking-pool/src/lib.rs
+++ b/contracts/mock-staking-pool/src/lib.rs
@@ -158,7 +158,9 @@ impl MockStakingPool {
 
     pub fn add_reward_for(&mut self, amount: U128, account_id: AccountId) {
         let staked_amount = self.internal_get_staked(&account_id);
-        assert!(staked_amount > 0);
+        // disable assert of `staked amount > 0` to test one special case that rewards are
+        // received when call `unstake()` on staking pool, which triggers `internal_ping()`
+        // assert!(staked_amount > 0);
 
         let new_amount = staked_amount + amount.0;
         self.staked.insert(&account_id, &new_amount);

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -14,21 +14,21 @@ import {
 
 const workspace = initWorkSpace();
 
-async function stakeAll (owner: NearAccount, contract: NearAccount) {
+async function stakeAll(owner: NearAccount, contract: NearAccount) {
   let run = true;
   while (run) {
     run = await epochStake(owner, contract);
   }
 }
 
-async function unstakeAll (owner: NearAccount, contract: NearAccount) {
+async function unstakeAll(owner: NearAccount, contract: NearAccount) {
   let run = true;
   while (run) {
     run = await epochUnstake(owner, contract);
   }
 }
 
-workspace.test('epoch stake', async (test, {root, contract, alice, owner, bob}) => {
+workspace.test('epoch stake', async (test, { root, contract, alice, owner, bob }) => {
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
   const v1 = await createStakingPool(root, 'v1');
@@ -168,7 +168,7 @@ workspace.test('epoch stake', async (test, {root, contract, alice, owner, bob}) 
   await assertValidator(v3, `${30 + 45 + 15}`, '0', '0');
 });
 
-workspace.test('epoch stake, staking pool with 1yN rounding diff', async (test, {root, contract, alice, owner, bob}) => {
+workspace.test('epoch stake, staking pool with 1yN rounding diff', async (test, { root, contract, alice, owner, bob }) => {
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
   const v1 = await createStakingPool(root, 'v1');
@@ -322,7 +322,7 @@ workspace.test('epoch stake, staking pool with 1yN rounding diff', async (test, 
   await assertValidator(v3, `${30 + 45 + 15}`, '0', '0');
 });
 
-workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => {
+workspace.test('epoch unstake', async (test, { root, contract, alice, owner }) => {
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
   const v1 = await createStakingPool(root, 'v1');
@@ -475,7 +475,7 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await assertValidator(v2, '16', '24', '0', '12');  // target = 12 (weighted); delta (1st) = 22.5 - 12 = 10.5; delta (2nd) = 16 - 12 = 4; 
   await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 37.5 - 18 = 19.5; delta (2nd) = 18 - 18 = 0;
 
- 
+
   // reset base stake amount of v1 to 0
   await updateBaseStakeAmounts(
     contract,
@@ -513,7 +513,7 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 18 - 18 = 0; delta (2nd) = 18 - 18 = 0; 
 });
 
-workspace.test('epoch unstake, staking pool with 1yN rounding diff', async (test, {root, contract, alice, owner}) => {
+workspace.test('epoch unstake, staking pool with 1yN rounding diff', async (test, { root, contract, alice, owner }) => {
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
   const v1 = await createStakingPool(root, 'v1');
@@ -677,7 +677,7 @@ workspace.test('epoch unstake, staking pool with 1yN rounding diff', async (test
   await assertValidator(v2, amountWithDiff('16', diff, -1), amountWithDiff('24', diff, 1), '0', '12');  // target = 12 (weighted); delta (1st) = 22.5 - 12 = 10.5; delta (2nd) = 16 - 12 = 4; 
   await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 37.5 - 18 = 19.5; delta (2nd) = 18 - 18 = 0;
 
- 
+
   // reset base stake amount of v1 to 0
   await updateBaseStakeAmounts(
     contract,
@@ -715,7 +715,7 @@ workspace.test('epoch unstake, staking pool with 1yN rounding diff', async (test
   await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 18 - 18 = 0; delta (2nd) = 18 - 18 = 0; 
 });
 
-workspace.test('epoch collect rewards', async (test, {root, contract, alice, owner}) => {
+workspace.test('epoch collect rewards', async (test, { root, contract, alice, owner }) => {
   test.timeout(60 * 1000);
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
@@ -856,12 +856,12 @@ workspace.test('epoch collect rewards', async (test, {root, contract, alice, own
 
   // set beneficiary
   await owner.call(
-      contract,
-      'set_beneficiary',
-      {
-          account_id: owner.accountId,
-          bps: 1000
-      }
+    contract,
+    'set_beneficiary',
+    {
+      account_id: owner.accountId,
+      bps: 1000
+    }
   );
 
   // generate more rewards
@@ -977,7 +977,7 @@ workspace.test('epoch collect rewards', async (test, {root, contract, alice, own
   await assertValidator(v3, "0", "33", "0");
 });
 
-workspace.test('epoch withdraw', async (test, {contract, alice, root, owner}) => {
+workspace.test('epoch withdraw', async (test, { contract, alice, root, owner }) => {
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
 
   const v1 = await createStakingPool(root, 'v1');
@@ -1126,7 +1126,7 @@ workspace.test('epoch withdraw', async (test, {contract, alice, root, owner}) =>
   await assertValidator(v3, '37.5', '0');
 });
 
-skip('estimate gas of epoch unstake', async (test, {contract, alice, root, owner}) => {
+skip('estimate gas of epoch unstake', async (test, { contract, alice, root, owner }) => {
   const validatorsNum = 255
 
   const names = Array.from({ length: validatorsNum }, (_, index) => `v${index + 1}`)
@@ -1148,7 +1148,7 @@ skip('estimate gas of epoch unstake', async (test, {contract, alice, root, owner
 
   let sliceIndex = 0
   const sliceSize = 6
-  while(sliceIndex < validators.length) {
+  while (sliceIndex < validators.length) {
     const validatorIdSlice = validators.slice(sliceIndex, sliceSize).map(v => v.accountId)
     const weightSlice = weights.slice(sliceIndex, sliceSize)
     await owner.call(

--- a/tests/__tests__/linear/epoch-action.ava.ts
+++ b/tests/__tests__/linear/epoch-action.ava.ts
@@ -8,7 +8,8 @@ import {
   assertValidatorAmountHelper,
   skip,
   epochStake,
-  epochUnstake
+  epochUnstake,
+  amountWithDiff
 } from "./helper";
 
 const workspace = initWorkSpace();
@@ -164,6 +165,160 @@ workspace.test('epoch stake', async (test, {root, contract, alice, owner, bob}) 
   // validators should have staked balance based on their weights + base stake amounts
   await assertValidator(v1, `${10 + 15 + 25}`, '0', '20');
   await assertValidator(v2, `${20 + 30 + 10}`, '0', '0');
+  await assertValidator(v3, `${30 + 45 + 15}`, '0', '0');
+});
+
+workspace.test('epoch stake, staking pool with 1yN rounding diff', async (test, {root, contract, alice, owner, bob}) => {
+  const assertValidator = assertValidatorAmountHelper(test, contract, owner);
+
+  const v1 = await createStakingPool(root, 'v1');
+  const v2 = await createStakingPool(root, 'v2');
+  const v3 = await createStakingPool(root, 'v3');
+
+  // 1 yN rounding diff from staking pool contract
+  const diff = NEAR.from(1);
+  await owner.call(
+    v1,
+    'set_balance_delta',
+    {
+      staked_delta: diff.toString(10),
+      unstaked_delta: diff.toString(10),
+    },
+  );
+
+  // add validators to contract
+  // weights:
+  // - v1: 10
+  // - v2: 20
+  // - v3: 30
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v1.accountId,
+      weight: 10
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v2.accountId,
+      weight: 20
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v3.accountId,
+      weight: 30
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+
+  // user stake
+  await alice.call(
+    contract,
+    'deposit_and_stake',
+    {},
+    {
+      attachedDeposit: NEAR.parse('50')
+    }
+  );
+
+  // at this time there should be no NEAR actually staked on validators
+  await assertValidator(v1, '0', '0');
+  await assertValidator(v2, '0', '0');
+  await assertValidator(v3, '0', '0');
+
+  // epoch stake
+  await stakeAll(owner, contract);
+
+  // validators should have staked balance based on their weights
+  // note that 10 NEAR is already staked when contract init
+  await assertValidator(v1, amountWithDiff('10', diff, -1), amountWithDiff('0', diff, 1));
+  await assertValidator(v2, '20', '0');
+  await assertValidator(v3, '30', '0');
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 11 }
+  );
+
+  // stake more
+  await bob.call(
+    contract,
+    'deposit_and_stake',
+    {},
+    {
+      attachedDeposit: NEAR.parse('90')
+    }
+  );
+
+  // epoch stake
+  await stakeAll(owner, contract);
+
+  // validators should have staked balance based on their weights
+  // note that 10 NEAR is already staked when contract init
+  await assertValidator(v1, amountWithDiff(`${10 + 15}`, diff, -2), amountWithDiff('0', diff, 2));
+  await assertValidator(v2, `${20 + 30}`, '0');
+  await assertValidator(v3, `${30 + 45}`, '0');
+
+
+  // ---- Test base stake amount ----
+
+  // set manager
+  const manager = await setManager(root, contract, owner);
+
+  // update base stake amount
+  await updateBaseStakeAmounts(
+    contract,
+    manager,
+    [
+      v1.accountId,
+    ],
+    [
+      NEAR.parse("20")
+    ]
+  );
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 12 }
+  );
+
+  // stake more
+  await bob.call(
+    contract,
+    'deposit_and_stake',
+    {},
+    {
+      attachedDeposit: NEAR.parse('50')
+    }
+  );
+
+  // epoch stake
+  await stakeAll(owner, contract);
+
+  // validators should have staked balance based on their weights + base stake amounts
+  // - v1 is selected first, and to meet the target amount, 25 N + 2 yN will be staked, which reduced the diff for staked amount
+  // - v3 is then selected since its delta is higher than v2, though their delta/target are the same
+  // - v2 is finally selected with 2 yN diff which is moved to v1
+  await assertValidator(v1, amountWithDiff(`${10 + 15 + 25}`, diff, -1), amountWithDiff('0', diff, 3), '20');
+  await assertValidator(v2, amountWithDiff(`${20 + 30 + 10}`, diff, -2), '0', '0');
   await assertValidator(v3, `${30 + 45 + 15}`, '0', '0');
 });
 
@@ -358,6 +513,208 @@ workspace.test('epoch unstake', async (test, {root, contract, alice, owner}) => 
   await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 18 - 18 = 0; delta (2nd) = 18 - 18 = 0; 
 });
 
+workspace.test('epoch unstake, staking pool with 1yN rounding diff', async (test, {root, contract, alice, owner}) => {
+  const assertValidator = assertValidatorAmountHelper(test, contract, owner);
+
+  const v1 = await createStakingPool(root, 'v1');
+  const v2 = await createStakingPool(root, 'v2');
+  const v3 = await createStakingPool(root, 'v3');
+
+  // 1 yN rounding diff from staking pool contract
+  const diff = NEAR.from(1);
+  await owner.call(
+    v1,
+    'set_balance_delta',
+    {
+      staked_delta: diff.toString(10),
+      unstaked_delta: diff.toString(10),
+    },
+  );
+
+  // add validators to contract
+  // weights:
+  // - v1: 10
+  // - v2: 20
+  // - v3: 30
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v1.accountId,
+      weight: 10
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v2.accountId,
+      weight: 20
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+  await owner.call(
+    contract,
+    'add_validator',
+    {
+      validator_id: v3.accountId,
+      weight: 30
+    },
+    {
+      gas: Gas.parse('100 Tgas')
+    }
+  );
+
+  // user stake
+  await alice.call(
+    contract,
+    'deposit_and_stake',
+    {},
+    {
+      attachedDeposit: NEAR.parse('110')
+    }
+  );
+
+  // epoch stake
+  await stakeAll(owner, contract);
+
+  // fast-forward epoch
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 14 }
+  );
+
+  // user unstake
+  await alice.call(
+    contract,
+    'unstake',
+    { amount: NEAR.parse('30') }
+  );
+
+  // at this time no actual unstake should happen
+  await assertValidator(v1, amountWithDiff('20', diff, -1), amountWithDiff('0', diff, 1));
+  await assertValidator(v2, '40', '0');
+  await assertValidator(v3, '60', '0');
+
+  // epoch unstake
+  await unstakeAll(owner, contract);
+
+  // 60 NEAR was initially staked, 30 was taken out
+  await assertValidator(v1, amountWithDiff('20', diff, -1), amountWithDiff('0', diff, 1));
+  await assertValidator(v2, '32.5', '7.5');
+  await assertValidator(v3, '37.5', '22.5');
+
+  // unstake more
+  await alice.call(
+    contract,
+    'unstake',
+    { amount: NEAR.parse('18') }
+  );
+
+  // epoch unstake should not take effect now
+  await assertValidator(v1, amountWithDiff('20', diff, -1), amountWithDiff('0', diff, 1));
+  await assertValidator(v2, '32.5', '7.5');
+  await assertValidator(v3, '37.5', '22.5');
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 18 }
+  );
+
+  await unstakeAll(owner, contract);
+
+  await assertValidator(v1, amountWithDiff('12', diff, -1), amountWithDiff('8', diff, 1));
+  await assertValidator(v2, amountWithDiff('22.5', diff, -1), amountWithDiff('17.5', diff, 1));
+  await assertValidator(v3, '37.5', '22.5');
+
+
+  // ---- Test base stake amount ----
+
+  // set manager
+  const manager = await setManager(root, contract, owner);
+
+  // update base stake amount of v1 to 10 NEAR
+  await updateBaseStakeAmounts(
+    contract,
+    manager,
+    [
+      v1.accountId,
+    ],
+    [
+      NEAR.parse("10")
+    ]
+  );
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 22 }
+  );
+
+  // unstake more; remaining total staked: 120 - 30 - 18 - 26 = 46
+  await alice.call(
+    contract,
+    'unstake',
+    { amount: NEAR.parse('26') }
+  );
+
+  // epoch unstake
+  await unstakeAll(owner, contract);
+
+  // validators should have target stake amount based on weights + base stake amounts
+  // - 1st epoch_unstake() unstaked 19.5 NEAR (amount = delta) from validator v3
+  // - 2nd epoch_unstake() unstaked 6.5 NEAR (amount = rest) from validator v2
+  await assertValidator(v1, amountWithDiff('12', diff, -1), amountWithDiff('8', diff, 1), '10', '16');   // target = 10 (base) + 6 (weighted) = 16; delta (1st) = 12 - 16 = -4; delta (2nd) = 12 - 16 = -4;
+  await assertValidator(v2, amountWithDiff('16', diff, -1), amountWithDiff('24', diff, 1), '0', '12');  // target = 12 (weighted); delta (1st) = 22.5 - 12 = 10.5; delta (2nd) = 16 - 12 = 4; 
+  await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 37.5 - 18 = 19.5; delta (2nd) = 18 - 18 = 0;
+
+ 
+  // reset base stake amount of v1 to 0
+  await updateBaseStakeAmounts(
+    contract,
+    manager,
+    [
+      v1.accountId,
+    ],
+    [
+      NEAR.parse("0")
+    ]
+  );
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 26 }
+  );
+
+  // unstake more; remaining total staked: 120 - 30 - 18 - 26 - 10 = 36
+  await alice.call(
+    contract,
+    'unstake',
+    { amount: NEAR.parse('10') }
+  );
+
+  // epoch unstake
+  await unstakeAll(owner, contract);
+
+  // validators should have target stake amount based on weights + base stake amounts
+  // - 1st epoch_unstake() unstaked 6 NEAR (amount = delta) from validator v1;
+  // - 2nd epoch_unstake() unstaked 4 NEAR (amount = rest) from validator v2;
+  await assertValidator(v1, amountWithDiff('6', diff, -1), amountWithDiff('14', diff, 1), '0', '6');   // target = 6 (weighted); delta (1st) = 12 - 6 = 6; delta (2nd) = 6 - 6 = 0;
+  await assertValidator(v2, amountWithDiff('12', diff, -2), amountWithDiff('28', diff, 2), '0', '12');  // target = 12 (weighted); delta (1st) = 16 - 12 = 4; delta (2nd) = 12 - 12 = 0;
+  await assertValidator(v3, '18', '42', '0', '18');   // target = 18 (weighted); delta (1st) = 18 - 18 = 0; delta (2nd) = 18 - 18 = 0; 
+});
+
 workspace.test('epoch collect rewards', async (test, {root, contract, alice, owner}) => {
   test.timeout(60 * 1000);
   const assertValidator = assertValidatorAmountHelper(test, contract, owner);
@@ -492,6 +849,11 @@ workspace.test('epoch collect rewards', async (test, {root, contract, alice, own
   test.truthy(total_share_amount_1.eq(NEAR.parse('70')));
   test.truthy(total_near_amount_1.eq(NEAR.parse('77')));
 
+  // check staked amount and base stake amount on each validator
+  await assertValidator(v1, "22", "0", "11");
+  await assertValidator(v2, "22", "0", "0");
+  await assertValidator(v3, "33", "0", "0");
+
   // set beneficiary
   await owner.call(
       contract,
@@ -535,6 +897,84 @@ workspace.test('epoch collect rewards', async (test, {root, contract, alice, own
   await assertValidator(v1, "24", "0", "12");
   await assertValidator(v2, "22", "0", "0");
   await assertValidator(v3, "33", "0", "0");
+
+  // fast-forward
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 14 }
+  );
+
+  const aliceBalance = await contract.view(
+    "get_account_total_balance",
+    { account_id: alice }
+  );
+  console.log("alice balance", aliceBalance);
+
+  // unstake 69 NEAR; remaining total staked: 79 - 67.5 = 11.5
+  await alice.call(
+    contract,
+    'unstake',
+    { amount: NEAR.parse('67.5') }
+  );
+
+  // epoch unstake
+  await unstakeAll(owner, contract);
+
+  // check staked amount and base stake amount on each validator
+  // There're 1yN diff due to rounding when alice unstakes 67.5 NEAR
+  const diff = NEAR.from(1);
+  await assertValidator(v1, amountWithDiff("11.5", diff, -1), amountWithDiff("12.5", diff, 1), "12");
+  await assertValidator(v2, "0", "22", "0");
+  await assertValidator(v3, "0", "33", "0");
+
+  // fast-forward 4 epoch
+  await owner.call(
+    contract,
+    'set_epoch_height',
+    { epoch: 18 }
+  );
+
+  // withdraw again
+  await owner.call(
+    contract,
+    'epoch_withdraw',
+    {
+      validator_id: v2.accountId
+    },
+    {
+      gas: Gas.parse('200 Tgas')
+    }
+  );
+
+  // check staked amount and base stake amount on each validator
+  await assertValidator(v1, amountWithDiff("11.5", diff, -1), amountWithDiff("12.5", diff, 1), "12");
+  await assertValidator(v2, "0", "0", "0");
+  await assertValidator(v3, "0", "33", "0");
+
+  // generate more rewards
+  await contract.call(
+    v2,
+    'add_reward',
+    { amount: NEAR.parse('2').toString() }
+  );
+
+  // update rewards for validator with 0 staked and unstaked amount
+  await owner.call(
+    contract,
+    'epoch_update_rewards',
+    {
+      validator_id: v2.accountId
+    },
+    {
+      gas: Gas.parse('200 Tgas')
+    }
+  );
+
+  // check staked amount and base stake amount on each validator
+  await assertValidator(v1, amountWithDiff("11.5", diff, -1), amountWithDiff("12.5", diff, 1), "12");
+  await assertValidator(v2, "2", "0", "0");
+  await assertValidator(v3, "0", "33", "0");
 });
 
 workspace.test('epoch withdraw', async (test, {contract, alice, root, owner}) => {

--- a/tests/__tests__/linear/helper.ts
+++ b/tests/__tests__/linear/helper.ts
@@ -337,6 +337,10 @@ export function assertValidatorAmountHelper (
   }
 }
 
+export function amountWithDiff(amount: string, diff: NEAR, numberOfDiff: number) {
+  return NEAR.parse(amount).add(diff.muln(numberOfDiff)).toHuman();
+}
+
 const EPOCH_STAKE_AND_UNSTAKE_GAS = Gas.parse('280 Tgas');
 
 export function epochStake(caller: NearAccount, contract: NearAccount): Promise<any> {


### PR DESCRIPTION
The reason to remove the restriction is that the LiNEAR contract may have staking rewards in some validators but not yet synced to the contract. 