### PR TITLE
feat: remove all liquidity from built-in liquidity pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "linear"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "near-contract-standards",
  "near-sdk 4.0.0-pre.7",

--- a/contracts/linear/Cargo.toml
+++ b/contracts/linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["linguists", "dongcool"]
 edition = "2018"
 publish = false

--- a/contracts/linear/src/events.rs
+++ b/contracts/linear/src/events.rs
@@ -182,6 +182,12 @@ pub enum Event<'a> {
         received_near: &'a U128,
         received_linear: &'a U128,
     },
+    RemoveAllLiquidity {
+        account_id: &'a AccountId,
+        burnt_shares: &'a U128,
+        received_near: &'a U128,
+        received_linear: &'a U128,
+    },
     LiquidityPoolSwapFee {
         account_id: &'a AccountId,
         stake_shares_in: &'a U128,

--- a/contracts/linear/src/liquidity_pool.rs
+++ b/contracts/linear/src/liquidity_pool.rs
@@ -448,10 +448,9 @@ impl LiquidStakingContract {
     pub fn remove_all_liquidity(&mut self, account_id: AccountId) -> Vec<U128> {
         self.assert_running();
 
-        // remove all account shares in liquidity pool
+        // Remove all shares of account from liquidity pool
         let account_lp_shares = self.liquidity_pool.get_account_shares(&account_id);
         require!(account_lp_shares > 0, ERR_ACCOUNT_NO_SHARE);
-        // Remove shares from liquidity pool
         let results = self
             .liquidity_pool
             .remove_liquidity(&account_id, account_lp_shares);

--- a/contracts/linear/src/liquidity_pool.rs
+++ b/contracts/linear/src/liquidity_pool.rs
@@ -459,7 +459,7 @@ impl LiquidStakingContract {
         let mut account = self.internal_get_account(&account_id);
         account.stake_shares += results[1];
         self.internal_save_account(&account_id, &account);
-        Promise::new(env::predecessor_account_id()).transfer(results[0]);
+        Promise::new(account_id.clone()).transfer(results[0]);
 
         Event::RemoveAllLiquidity {
             account_id: &account_id,

--- a/tests/__tests__/linear/liquidity-pool.ava.ts
+++ b/tests/__tests__/linear/liquidity-pool.ava.ts
@@ -631,7 +631,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     amount: NEAR.parse('10')
   });
 
-  // Alice removes all liquidity
+  // Removes all liquidity of Alice
   await removeAllLiquidity(test, {
     contract,
     operator: alice,
@@ -639,7 +639,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     loss: '3' // yoctoN
   });
 
-  // Bob removes all liquidity
+  // Removes all liquidity of Bob
   await removeAllLiquidity(test, {
     contract,
     operator: alice,
@@ -647,7 +647,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     loss: '500' // yoctoN
   });
 
-  // Carol removes all liquidity
+  // Removes all liquidity of Carol
   await removeAllLiquidity(test, {
     contract,
     operator: alice,
@@ -655,7 +655,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     loss: '3' // yoctoN
   });
 
-  // Alice cannot remove more liquidity
+  // Cannot remove more liquidity of Bob
   await assertFailure(
     test,
     removeAllLiquidity(test, {

--- a/tests/__tests__/linear/liquidity-pool.ava.ts
+++ b/tests/__tests__/linear/liquidity-pool.ava.ts
@@ -640,7 +640,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
   await removeAllLiquidity(test, {
     contract,
     user: bob,
-    loss: '3' // yoctoN
+    loss: '500' // yoctoN
   });
 
   // Carol removes all liquidity
@@ -649,4 +649,10 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     user: carol,
     loss: '3' // yoctoN
   });
+
+  // All NEAR and LiNEAR left in the liquidity pool
+  test.is(
+    (await getPoolValue(contract)).toString(),
+    "0"
+  );
 });

--- a/tests/__tests__/linear/liquidity-pool.ava.ts
+++ b/tests/__tests__/linear/liquidity-pool.ava.ts
@@ -650,7 +650,7 @@ workspace.test('issue: panick if remove account total liquidity (LiNEAR price > 
     loss: '3' // yoctoN
   });
 
-  // All NEAR and LiNEAR left in the liquidity pool
+  // No NEAR and LiNEAR left in the liquidity pool
   test.is(
     (await getPoolValue(contract)).toString(),
     "0"


### PR DESCRIPTION
As we're going to completely deprecate liquidity pool, add the `remove_all_liquidity()` function that allows removing all liquidity for one given user and return NEAR and LiNEAR
