### PR TITLE
fix: reward callback failure unlock

### DIFF
--- a/contracts/linear/src/epoch_actions.rs
+++ b/contracts/linear/src/epoch_actions.rs
@@ -378,12 +378,24 @@ impl LiquidStakingContract {
     pub fn validator_get_balance_callback(
         &mut self,
         validator_id: AccountId,
-        #[callback] total_balance: U128,
+        #[callback_result] result: Result<U128, PromiseError>,
     ) {
         let mut validator = self
             .validator_pool
             .get_validator(&validator_id)
             .expect(ERR_VALIDATOR_NOT_EXIST);
+
+        let total_balance = match result {
+            Ok(total_balance) => total_balance,
+            Err(_) => {
+                validator.on_refresh_total_balance_failed(&mut self.validator_pool);
+                log!(
+                    "Failed to refresh total balance from validator {}",
+                    validator_id
+                );
+                return;
+            }
+        };
 
         let new_balance = total_balance.0;
         let rewards = new_balance - validator.total_balance();

--- a/contracts/linear/src/validator_pool.rs
+++ b/contracts/linear/src/validator_pool.rs
@@ -1049,6 +1049,10 @@ impl Validator {
         pool.save_validator(self);
     }
 
+    pub fn on_refresh_total_balance_failed(&mut self, pool: &mut ValidatorPool) {
+        self.post_execution(pool);
+    }
+
     /// Due to shares calculation and rounding of staking pool contract,
     /// the amount of staked and unstaked balance might be a little bit
     /// different than we requested.

--- a/tests/__tests__/linear/epoch-action-failure.ava.ts
+++ b/tests/__tests__/linear/epoch-action-failure.ava.ts
@@ -441,4 +441,22 @@ test('get balance failure', async (t) => {
 
   // balance should not change
   await assertValidator(v1, '60', '0');
+
+  await v1.call(v1, 'set_panic', {
+    panic: false,
+  });
+
+  // update reward should be retryable after the failed callback releases executing
+  await owner.call(
+    contract,
+    'epoch_update_rewards',
+    {
+      validator_id: v1.accountId,
+    },
+    {
+      gas: Gas.parse('200 Tgas'),
+    },
+  );
+
+  await assertValidator(v1, '61', '0');
 });


### PR DESCRIPTION
  ## Summary

  This PR prevents a validator from remaining locked if the reward balance refresh callback receives a failed external promise.

  ## Problem

  `epoch_update_rewards()` sets the validator into `executing` state before calling the external staking pool. The callback previously used `#[callback]`, which panics
  before entering the function body if the external call fails.

  In that failure case, the validator never reaches the normal `post_execution()` path, so it can remain stuck in `executing = true` and block future operations for that
  validator.

  ## Fix

  Change `validator_get_balance_callback` to use `#[callback_result]`.

  On success, the existing reward update logic is unchanged. On failure, the callback clears the validator execution flag and returns without updating rewards.

  ## Testing

  CI passed:
  - `test`
  - `clippy and fmt`