### PR TITLE
docs: clarify validator drain runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,45 @@ In order to use it, run `npm i` first.
 Drain is to totally remove a validator from candidate list, all funds on it will be re-distributed
 among others.
 
-1. Make sure there is currently no unstaked balance on it. If there is, call `epoch_withdraw` to withdraw.
-2. Set validator weight to 0, which can be done by either removing this validator from nodes list or set its weight to 0 directly. Run `set-node` command to update the weight.
-3. Run `drain-unstake` to unstake all funds from the validator.
-4. After 4 epochs, run `drain-withdraw` to withdraw and restake those funds.
+Drain is a manager operation. Before starting it, make sure the local validator
+accounting has been synced with the validator staking pool so the drain amount is
+selected from the latest balances.
+
+1. Stop assigning new stake to the validator:
+   - Set validator weight to `0`, which can be done by either removing this
+     validator from nodes list or setting its weight to `0` directly. Run
+     `set-node` command to update the weight.
+   - Set validator base stake amount to `0`. Run `set-node-base-amounts` command
+     to update the base stake amount.
+2. Sync the validator balance before drain:
+   - Call `epoch_update_rewards` for the validator and wait for the callback to
+     succeed. This records any staking pool rewards before the drain amount is
+     selected.
+   - Call `sync_balance_from_validator` for the validator and wait for the
+     callback to succeed. This aligns local `staked_amount` and `unstaked_amount`
+     with the staking pool account.
+   - If either callback fails, retry and do not continue to `drain-unstake`.
+3. Settle unstaked balance before drain:
+   - If `get_validator` shows `unstaked_amount` greater than or equal to `1 NEAR`,
+     call `epoch_withdraw` and wait for the callback to succeed.
+   - After `epoch_withdraw`, call `sync_balance_from_validator` again and wait
+     for the callback to succeed.
+4. Verify `get_validator` before `drain-unstake`:
+   - `weight` is `0`.
+   - `base_stake_amount` is `0`.
+   - `pending_release` is `false`.
+   - `unstaked_amount` is less than `1 NEAR`.
+   - `draining` is `false`.
+5. Run `drain-unstake` to unstake all funds from the validator.
+6. After 4 epochs, verify `get_validator` again:
+   - `weight` is `0`.
+   - `base_stake_amount` is `0`.
+   - `staked_amount` is `0`.
+   - `pending_release` is `false`.
+   - `draining` is `true`.
+7. Run `drain-withdraw` to withdraw the drained funds. The callback adds the
+   withdrawn amount back to the epoch stake request so it can be restaked to
+   other validators.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -96,18 +96,22 @@ selected from the latest balances.
      with the staking pool account.
    - If either callback fails, retry and do not continue to `drain-unstake`.
 3. Settle unstaked balance before drain:
-   - If `get_validator` shows `unstaked_amount` greater than or equal to `1 NEAR`,
-     call `epoch_withdraw` and wait for the callback to succeed.
+   - If `get_validator` shows `unstaked_amount` greater than or equal to `1 NEAR`
+     (`1_000_000_000_000_000_000_000_000 yoctoNEAR`), call `epoch_withdraw`
+     and wait for the callback to succeed. The drain guard only tolerates less
+     than `1 NEAR` as staking-pool precision dust.
    - After `epoch_withdraw`, call `sync_balance_from_validator` again and wait
      for the callback to succeed.
 4. Verify `get_validator` before `drain-unstake`:
    - `weight` is `0`.
    - `base_stake_amount` is `0`.
    - `pending_release` is `false`.
-   - `unstaked_amount` is less than `1 NEAR`.
+   - `unstaked_amount` is less than `1 NEAR`
+     (`1_000_000_000_000_000_000_000_000 yoctoNEAR`).
    - `draining` is `false`.
 5. Run `drain-unstake` to unstake all funds from the validator.
-6. After 4 epochs, verify `get_validator` again:
+6. After 4 full epochs have passed since the `drain-unstake` transaction
+   finalized and its callback succeeded on-chain, verify `get_validator` again:
    - `weight` is `0`.
    - `base_stake_amount` is `0`.
    - `staked_amount` is `0`.


### PR DESCRIPTION
  ## Summary

  This PR updates the validator drain documentation to make the operational runbook explicit.

  ## Problem

  The existing drain instructions described the basic `drain-unstake` / `drain-withdraw` flow, but they did not clearly require syncing validator accounting
  with the staking pool before selecting the drain amount. They also did not mention the `base_stake_amount = 0` precondition that the contract enforces.

  ## Update

  The drain runbook now documents the required sequence:

  - Set validator weight to `0`.
  - Set validator base stake amount to `0`.
  - Run `epoch_update_rewards` before drain and wait for the callback to succeed.
  - Run `sync_balance_from_validator` and wait for the callback to succeed.
  - Settle any meaningful unstaked balance before `drain-unstake`.
  - Verify the relevant `get_validator` fields before `drain-unstake` and before `drain-withdraw`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded "Manage → Drain" into a detailed step-by-step procedure: frames Drain as a manager operation, requires selecting drain amounts from up-to-date balances, handles callback failure/retry before proceeding, settles unstaked balances once thresholds are met, verifies validator state before unstaking and again after 4 epochs, and clarifies how drained funds are restarted into epoch stake requests for restaking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linear-protocol/LiNEAR/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->